### PR TITLE
viser ulik tekst til deltaker avhengig av status

### DIFF
--- a/apps/innbyggers-flate/src/components/DeltakerStatusInfoTekst.tsx
+++ b/apps/innbyggers-flate/src/components/DeltakerStatusInfoTekst.tsx
@@ -1,0 +1,48 @@
+import { DeltakerStatusType } from '../api/data/deltaker.ts'
+import { BodyLong } from '@navikt/ds-react'
+import { EMDASH } from '../utils/utils.ts'
+
+interface DeltakerStatusInfoTekstProps {
+  statusType: DeltakerStatusType
+  tiltakOgStedTekst: string
+  oppstartsdato: string | null
+}
+
+const getInfoTekst = (
+  status: DeltakerStatusType,
+  tiltakOgStedTekst: string,
+  harOppstartsdato: boolean
+) => {
+  switch (status) {
+    case DeltakerStatusType.VENTER_PA_OPPSTART:
+      if (harOppstartsdato) {
+        return `Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+      } else {
+        return `Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}. Når arrangøren har en ledig plass så vil de ta kontakt med deg for å avklare oppstart.`
+      }
+    case DeltakerStatusType.DELTAR:
+      return `Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+    case DeltakerStatusType.HAR_SLUTTET:
+      return `Du deltok på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+    case DeltakerStatusType.IKKE_AKTUELL:
+      return `${tiltakOgStedTekst} ble ikke aktuelt.`
+    default:
+      return 'TODO'
+  }
+}
+
+export const DeltakerStatusInfoTekst = ({
+  statusType,
+  tiltakOgStedTekst,
+  oppstartsdato
+}: DeltakerStatusInfoTekstProps) => {
+  return (
+    <BodyLong size="small" className="mt-4">
+      {getInfoTekst(
+        statusType,
+        tiltakOgStedTekst,
+        oppstartsdato !== null && oppstartsdato !== EMDASH
+      )}
+    </BodyLong>
+  )
+}

--- a/apps/innbyggers-flate/src/components/demo-banner/DemoStatusInstillinger.tsx
+++ b/apps/innbyggers-flate/src/components/demo-banner/DemoStatusInstillinger.tsx
@@ -78,6 +78,9 @@ const DemoStatusInstillinger = () => {
       <option value={DeltakerStatusType.HAR_SLUTTET}>
         {getDeltakerStatusDisplayText(DeltakerStatusType.HAR_SLUTTET)}
       </option>
+      <option value={DeltakerStatusType.AVBRUTT_UTKAST}>
+        {getDeltakerStatusDisplayText(DeltakerStatusType.AVBRUTT_UTKAST)}
+      </option>
     </Select>
   )
 }

--- a/apps/innbyggers-flate/src/pages/TiltakPage.tsx
+++ b/apps/innbyggers-flate/src/pages/TiltakPage.tsx
@@ -26,6 +26,7 @@ import { ChatElipsisIcon, ChevronRightIcon } from '@navikt/aksel-icons'
 import { getDialogUrl } from '../utils/environment-utils.ts'
 import { DeltakerStatusTag } from '../components/DeltakerStatusTag.tsx'
 import { HvaErDette } from '../components/HvaErDette.tsx'
+import { DeltakerStatusInfoTekst } from '../components/DeltakerStatusInfoTekst.tsx'
 
 const skalViseDeltakelsesmengde = (deltaker: DeltakerResponse) => {
   return (
@@ -101,9 +102,11 @@ export const TiltakPage = () => {
           <BodyShort>{dato}</BodyShort>
         </HStack>
       )}
-      <BodyLong size="small" className="mt-4">
-        {`Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}. Når arrangøren har en ledig plass så vil de ta kontakt med deg for å avklare oppstart.`}
-      </BodyLong>
+      <DeltakerStatusInfoTekst
+        statusType={deltaker.status.type}
+        tiltakOgStedTekst={tiltakOgStedTekst}
+        oppstartsdato={deltaker.startdato}
+      />
 
       <Heading level="2" size="medium" className="mt-8">
         Hva er innholdet?

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../api/data/pamelding.ts'
 import { HvaErDette } from './HvaErDette.tsx'
 import { getDialogUrl } from '../../utils/environment-utils.ts'
+import { DeltakerStatusInfoTekst } from './DeltakerStatusInfoTekst.tsx'
 
 interface Props {
   className: string
@@ -106,9 +107,11 @@ export const DeltakerInfo = ({ className }: Props) => {
           <BodyShort>{dato}</BodyShort>
         </HStack>
       )}
-      <BodyLong size="small" className="mt-4">
-        {`Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}. Når arrangøren har en ledig plass så vil de ta kontakt med deg for å avklare oppstart.`}
-      </BodyLong>
+      <DeltakerStatusInfoTekst
+        statusType={pamelding.status.type}
+        tiltakOgStedTekst={tiltakOgStedTekst}
+        oppstartsdato={pamelding.startdato}
+      />
 
       <Heading level="2" size="medium" className="mt-8">
         Hva er innholdet?

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerStatusInfoTekst.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerStatusInfoTekst.tsx
@@ -1,0 +1,48 @@
+import { BodyLong } from '@navikt/ds-react'
+import { DeltakerStatusType } from '../../api/data/pamelding.ts'
+import { EMDASH } from '../../utils/utils.ts'
+
+interface DeltakerStatusInfoTekstProps {
+  statusType: DeltakerStatusType
+  tiltakOgStedTekst: string
+  oppstartsdato: string | null
+}
+
+const getInfoTekst = (
+  status: DeltakerStatusType,
+  tiltakOgStedTekst: string,
+  harOppstartsdato: boolean
+) => {
+  switch (status) {
+    case DeltakerStatusType.VENTER_PA_OPPSTART:
+      if (harOppstartsdato) {
+        return `Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+      } else {
+        return `Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}. Når arrangøren har en ledig plass så vil de ta kontakt med deg for å avklare oppstart.`
+      }
+    case DeltakerStatusType.DELTAR:
+      return `Du er meldt på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+    case DeltakerStatusType.HAR_SLUTTET:
+      return `Du deltok på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+    case DeltakerStatusType.IKKE_AKTUELL:
+      return `${tiltakOgStedTekst} ble ikke aktuelt.`
+    default:
+      return 'TODO'
+  }
+}
+
+export const DeltakerStatusInfoTekst = ({
+  statusType,
+  tiltakOgStedTekst,
+  oppstartsdato
+}: DeltakerStatusInfoTekstProps) => {
+  return (
+    <BodyLong size="small" className="mt-4">
+      {getInfoTekst(
+        statusType,
+        tiltakOgStedTekst,
+        oppstartsdato !== null && oppstartsdato !== EMDASH
+      )}
+    </BodyLong>
+  )
+}


### PR DESCRIPTION
Infoteksten som vises til deltaker skal være litt forskjellig avhengig av status og om de har oppstartsdato, se skisse: https://www.figma.com/file/cyeLG9ZWG3lCAHgkyeOEVR/Komet-Library-Veileder-Innbygger?type=design&node-id=0-1&mode=design&t=6CrkXzMR7CkxhvWl-0

Det mangler tekster for en del av statusene, derfor returnerer den "TODO" som tekst frem til vi får avklart hva teksten skal være for resterende statuser :)

Denne komponenten hadde vært glitrende å trekke ut i noe felles, men siden vi bare har fellesoppsett for config vet jeg ikke hvordan jeg skal gjøre det for komponenter, så da ble det duplisering i stedet.. 