### PR TITLE
viser avbrutt utkast for innbygger

### DIFF
--- a/apps/innbyggers-flate/src/components/UtkastHeader.tsx
+++ b/apps/innbyggers-flate/src/components/UtkastHeader.tsx
@@ -1,0 +1,45 @@
+import { Detail, HStack } from '@navikt/ds-react'
+import { Vedtaksinformasjon } from '../api/data/deltaker.ts'
+import { formatDateStrWithMonthName } from '../utils/utils.ts'
+
+interface Props {
+  vedtaksinformasjon: Vedtaksinformasjon | null
+}
+
+export const UtkastHeader = ({ vedtaksinformasjon }: Props) => {
+  const erEndret =
+    vedtaksinformasjon?.sistEndret !== vedtaksinformasjon?.opprettet ||
+    vedtaksinformasjon?.sistEndretAv !== vedtaksinformasjon?.opprettetAv
+
+  return (
+    <div className="space-y-2 mt-2 mb-4">
+      {vedtaksinformasjon &&
+        (erEndret ? (
+          <>
+            <HStack className="mt-0" gap="2">
+              <Detail weight="semibold">Første utkast delt:</Detail>
+              <Detail>
+                {formatDateStrWithMonthName(vedtaksinformasjon.opprettet)}{' '}
+                {vedtaksinformasjon.opprettetAv}
+              </Detail>
+            </HStack>
+            <HStack gap="2">
+              <Detail weight="semibold">Sist endret:</Detail>
+              <Detail>
+                {formatDateStrWithMonthName(vedtaksinformasjon.sistEndret)}{' '}
+                {vedtaksinformasjon.sistEndretAv}
+              </Detail>
+            </HStack>
+          </>
+        ) : (
+          <HStack gap="2">
+            <Detail weight="semibold">Delt:</Detail>
+            <Detail>
+              {formatDateStrWithMonthName(vedtaksinformasjon.opprettet)}{' '}
+              {vedtaksinformasjon.opprettetAv}
+            </Detail>
+          </HStack>
+        ))}
+    </div>
+  )
+}

--- a/apps/innbyggers-flate/src/guards/DeltakerGuard.tsx
+++ b/apps/innbyggers-flate/src/guards/DeltakerGuard.tsx
@@ -2,6 +2,7 @@ import { useDeltakerContext } from '../DeltakerContext'
 import { DeltakerStatusType } from '../api/data/deltaker'
 import { UtkastPage } from '../pages/UtkastPage'
 import { TiltakPage } from '../pages/TiltakPage'
+import { AvbruttUtkastPage } from '../pages/AvbruttUtkastPage.tsx'
 
 export const DeltakerGuard = () => {
   const { deltaker } = useDeltakerContext()
@@ -10,6 +11,8 @@ export const DeltakerGuard = () => {
 
   if (deltaker.status.type === DeltakerStatusType.UTKAST_TIL_PAMELDING) {
     pageToLoad = <UtkastPage />
+  } else if (deltaker.status.type === DeltakerStatusType.AVBRUTT_UTKAST) {
+    pageToLoad = <AvbruttUtkastPage />
   } else {
     pageToLoad = <TiltakPage />
   }

--- a/apps/innbyggers-flate/src/pages/AvbruttUtkastPage.tsx
+++ b/apps/innbyggers-flate/src/pages/AvbruttUtkastPage.tsx
@@ -1,0 +1,67 @@
+import { BodyLong, Heading, List } from '@navikt/ds-react'
+import { EMDASH, hentTiltakNavnHosArrangørTekst } from '../utils/utils'
+import { useDeltakerContext } from '../DeltakerContext'
+import { Tiltakstype } from '../api/data/deltaker'
+import { UtkastHeader } from '../components/UtkastHeader.tsx'
+
+export const AvbruttUtkastPage = () => {
+  const { deltaker } = useDeltakerContext()
+  const tiltakOgStedTekst = hentTiltakNavnHosArrangørTekst(
+    deltaker.deltakerliste.tiltakstype,
+    deltaker.deltakerliste.arrangorNavn
+  )
+  const dagerIUkaText = deltaker.dagerPerUke
+    ? `${deltaker.dagerPerUke} ${deltaker.dagerPerUke > 1 ? 'dager' : 'dag'} i uka`
+    : ''
+
+  return (
+    <div className="flex flex-col items-start mb-4">
+      <Heading level="1" size="large">
+        Avbrutt utkast
+      </Heading>
+      <UtkastHeader vedtaksinformasjon={deltaker.vedtaksinformasjon} />
+      <Heading level="2" size="medium">
+        {tiltakOgStedTekst}
+      </Heading>
+
+      <Heading level="2" size="medium" className="mt-6">
+        Hva er innholdet?
+      </Heading>
+      {deltaker.deltakelsesinnhold?.ledetekst && (
+        <BodyLong size="small" className="mt-2">
+          {deltaker.deltakelsesinnhold?.ledetekst}
+        </BodyLong>
+      )}
+
+      {deltaker.deltakelsesinnhold?.innhold && (
+        <List as="ul" size="small" className="mt-2">
+          {deltaker.deltakelsesinnhold.innhold.map((innhold) => (
+            <List.Item key={innhold.innholdskode}>
+              {innhold.tekst}
+              {innhold.beskrivelse ? `: ${innhold.beskrivelse}` : ''}
+            </List.Item>
+          ))}
+        </List>
+      )}
+
+      <Heading level="2" size="medium" className="mt-6">
+        Bakgrunnsinfo
+      </Heading>
+      <BodyLong size="small" className="mt-2">
+        {deltaker.bakgrunnsinformasjon || EMDASH}
+      </BodyLong>
+
+      {(deltaker.deltakerliste.tiltakstype === Tiltakstype.ARBFORB ||
+        deltaker.deltakerliste.tiltakstype === Tiltakstype.VASV) && (
+        <>
+          <Heading level="2" size="medium" className="mt-6">
+            Deltakelsesmengde
+          </Heading>
+          <BodyLong size="small" className="mt-2">
+            {`${deltaker.deltakelsesprosent ?? 100}\u00A0% ${dagerIUkaText}`}
+          </BodyLong>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/innbyggers-flate/src/pages/UtkastPage.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastPage.tsx
@@ -1,7 +1,6 @@
 import {
   BodyLong,
   Button,
-  Detail,
   GuidePanel,
   Heading,
   List,
@@ -10,11 +9,7 @@ import {
 } from '@navikt/ds-react'
 import { ThumbUpIcon } from '@navikt/aksel-icons'
 import { svg } from '../ikoner/nav-veileder'
-import {
-  EMDASH,
-  formatDateStrWithMonthName,
-  hentTiltakNavnHosArrangørTekst
-} from '../utils/utils'
+import { EMDASH, hentTiltakNavnHosArrangørTekst } from '../utils/utils'
 import { useParams } from 'react-router-dom'
 import { DeferredFetchState, useDeferredFetch } from '../hooks/useDeferredFetch'
 import { godkjennUtkast } from '../api/api'
@@ -22,6 +17,7 @@ import { VilIkkeGodkjenneExpansionCard } from '../components/VilIkkeGodkjenneExp
 import { useDeltakerContext } from '../DeltakerContext'
 import { Tiltakstype } from '../api/data/deltaker'
 import { PERSONOPPLYSNINGER_URL } from '../utils/environment-utils'
+import { UtkastHeader } from '../components/UtkastHeader.tsx'
 
 export const UtkastPage = () => {
   const { deltaker, setDeltaker } = useDeltakerContext()
@@ -49,18 +45,7 @@ export const UtkastPage = () => {
       <Heading level="1" size="large">
         Utkast til påmelding
       </Heading>
-      {deltaker.vedtaksinformasjon?.sistEndret && (
-        <div className="flex gap-2 mt-2">
-          <Detail weight="semibold">Sist endret:</Detail>
-          <Detail>
-            {formatDateStrWithMonthName(
-              deltaker.vedtaksinformasjon?.sistEndret
-            )}{' '}
-            {deltaker.vedtaksinformasjon?.sistEndretAv}
-          </Detail>
-        </div>
-      )}
-
+      <UtkastHeader vedtaksinformasjon={deltaker.vedtaksinformasjon} />
       <GuidePanel poster illustration={svg} className="mt-4">
         <Heading level="2" size="small">
           Dette er et utkast til påmelding til{' '}


### PR DESCRIPTION
https://trello.com/c/K7Eikwxm/1536-avbrutt-utkast-visning-av-tiltakssiden

Endret også endringsinfo for utkast-siden så man kan se først delt og sist endret, tilsvarende som for veileder-siden. 

Valgte å lage helt egen visning for avbrutt utkast siden den er ganske ulik de andre statusene. 