### PR TITLE
legger til sluttårsak for avlyst gjennomføring

### DIFF
--- a/apps/nav-veileders-flate/src/utils/displayText.ts
+++ b/apps/nav-veileders-flate/src/utils/displayText.ts
@@ -22,6 +22,8 @@ export const getDeltakerStatusAarsakTypeText = (
       return 'Trenger annen hjelp og støtte'
     case DeltakerStatusAarsakType.UTDANNING:
       return 'Utdanning'
+    case DeltakerStatusAarsakType.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT:
+      return 'Samarbeidet med arrangøren er avbrutt'
   }
 }
 

--- a/apps/nav-veileders-flate/src/utils/utils.ts
+++ b/apps/nav-veileders-flate/src/utils/utils.ts
@@ -56,7 +56,11 @@ export const erGyldigDagerPerUke = (value: string) => {
 
 export const getDeltakerStatusAarsakTyperAsList = () => {
   const arsakstyper = Object.keys(DeltakerStatusAarsakType)
-    .filter((type) => type !== DeltakerStatusAarsakType.ANNET)
+    .filter(
+      (type) =>
+        type !== DeltakerStatusAarsakType.ANNET &&
+        type !== DeltakerStatusAarsakType.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT
+    )
     .map((typeString) => {
       // @ts-expect-error: arsakType is made from DeltakerStatusAarsakType keys
       const typeKey: keyof typeof DeltakerStatusAarsakType = typeString

--- a/packages/deltaker-flate-common/model/deltaker.ts
+++ b/packages/deltaker-flate-common/model/deltaker.ts
@@ -35,7 +35,8 @@ export enum DeltakerStatusAarsakType {
   TRENGER_ANNEN_STOTTE = 'TRENGER_ANNEN_STOTTE',
   UTDANNING = 'UTDANNING',
   IKKE_MOTT = 'IKKE_MOTT',
-  ANNET = 'ANNET'
+  ANNET = 'ANNET',
+  SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT = 'SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT'
 }
 
 export const tiltakstypeSchema = z.nativeEnum(Tiltakstype)

--- a/packages/deltaker-flate-common/utils/displayText.ts
+++ b/packages/deltaker-flate-common/utils/displayText.ts
@@ -92,5 +92,7 @@ export const getDeltakerStatusAarsakText = (aarsak: DeltakerStatusAarsak) => {
       return 'Trenger annen hjelp og støtte'
     case DeltakerStatusAarsakType.UTDANNING:
       return 'Utdanning'
+    case DeltakerStatusAarsakType.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT:
+      return 'Samarbeidet med arrangøren er avbrutt'
   }
 }


### PR DESCRIPTION
https://trello.com/c/nTtjDfmG/1391-avlyst-tiltaksgjennomf%C3%B8ring-hos-valp-p%C3%A5virker-deltakerstatus-og-%C3%A5rsak

Denne sluttårsaken skal ikke være noe man kan velge i frontend, den skal settes maskinelt hvis gjennomføringen blir avlyst hos Valp :)