### PR TITLE
Fjerner tekst om sluttdato dersom sluttdato mangler i endringsmeldingen

### DIFF
--- a/packages/deltaker-flate-common/components/forslag/ForslagDetaljer.tsx
+++ b/packages/deltaker-flate-common/components/forslag/ForslagDetaljer.tsx
@@ -81,9 +81,11 @@ export const ForslagtypeDetaljer = ({ forslag }: { forslag: Forslag }) => {
             <BodyLong size="small">
               Ny oppstartsdato: {formatDate(forslag.endring.startdato)}
             </BodyLong>
-            <BodyLong size="small">
-              Forventet sluttdato: {formatDate(forslag.endring.sluttdato)}
-            </BodyLong>
+            {forslag.endring.sluttdato && (
+              <BodyLong size="small">
+                Forventet sluttdato: {formatDate(forslag.endring.sluttdato)}
+              </BodyLong>
+            )}
           </>
         )
       case ForslagEndringType.Sluttarsak:

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEndring.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEndring.tsx
@@ -115,9 +115,11 @@ const getEndringsDetaljer = (endring: Endring) => {
     case EndringType.EndreStartdato: {
       return (
         <>
-          <BodyLong size="small">
-            Forventet sluttdato: {formatDate(endring.sluttdato)}
-          </BodyLong>
+          {endring.sluttdato && (
+            <BodyLong size="small">
+              Forventet sluttdato: {formatDate(endring.sluttdato)}
+            </BodyLong>
+          )}
           {endring.begrunnelse && (
             <BodyLong size="small" className="whitespace-pre-wrap">
               Navs begrunnelse: {endring.begrunnelse}

--- a/packages/deltaker-flate-common/model/deltakerHistorikk.ts
+++ b/packages/deltaker-flate-common/model/deltakerHistorikk.ts
@@ -46,7 +46,7 @@ export const endreDeltakelsesmengdeSchema = z.object({
 export const endreStartdatoSchema = z.object({
   type: z.literal(EndringType.EndreStartdato),
   startdato: dateSchema,
-  sluttdato: dateSchema,
+  sluttdato: nullableDateSchema,
   begrunnelse: z.string().nullable()
 })
 
@@ -103,7 +103,7 @@ const endringSchema = z.discriminatedUnion('type', [
 const arrangorLeggTilOppstartSchema = z.object({
   type: z.literal(ArrangorEndringsType.LeggTilOppstartsdato),
   startdato: dateSchema,
-  sluttdato: dateSchema
+  sluttdato: nullableDateSchema
 })
 
 const arrangorEndringSchema = z.discriminatedUnion('type', [

--- a/packages/deltaker-flate-common/utils/mockData.ts
+++ b/packages/deltaker-flate-common/utils/mockData.ts
@@ -113,6 +113,34 @@ export const createHistorikk = (): DeltakerHistorikkListe => {
     {
       type: HistorikkType.Endring,
       endring: {
+        type: EndringType.EndreStartdato,
+        sluttdato: null,
+        startdato: dayjs().toDate(),
+        begrunnelse: null
+      },
+      endretAv: 'Navn Navnesen',
+      endretAvEnhet: 'Nav Fredrikstad',
+      endret: dayjs().subtract(2, 'day').toDate(),
+      forslag: {
+        id: uuidv4(),
+        type: HistorikkType.Forslag,
+        opprettet: dayjs().toDate(),
+        begrunnelse: 'Trenger mer tid',
+        arrangorNavn: 'Muligheter As',
+        endring: {
+          type: ForslagEndringType.Startdato,
+          sluttdato: dayjs().add(4, 'month').toDate(),
+          startdato: dayjs().add(1, 'month').toDate()
+        },
+        status: {
+          type: ForslagStatusType.Godkjent,
+          godkjent: dayjs().toDate()
+        }
+      }
+    },
+    {
+      type: HistorikkType.Endring,
+      endring: {
         type: EndringType.ReaktiverDeltakelse,
         reaktivertDato: dayjs().toDate(),
         begrunnelse:

--- a/packages/deltaker-flate-common/utils/mockData.ts
+++ b/packages/deltaker-flate-common/utils/mockData.ts
@@ -129,7 +129,7 @@ export const createHistorikk = (): DeltakerHistorikkListe => {
         arrangorNavn: 'Muligheter As',
         endring: {
           type: ForslagEndringType.Startdato,
-          sluttdato: dayjs().add(4, 'month').toDate(),
+          sluttdato: null,
           startdato: dayjs().add(1, 'month').toDate()
         },
         status: {


### PR DESCRIPTION
<img width="643" alt="image" src="https://github.com/user-attachments/assets/f731f8ce-9f94-4f0a-b82a-83132b024519">
