### PR TITLE
Endre feilmeldinger for endringer som bare har tekstfelt

### DIFF
--- a/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndreBakgrunnsinfoModal.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndreBakgrunnsinfoModal.tsx
@@ -5,7 +5,7 @@ import { useAppContext } from '../../../AppContext.tsx'
 import { endreDeltakelseBakgrunnsinfo } from '../../../api/api.ts'
 import { PameldingResponse } from '../../../api/data/pamelding.ts'
 import { BAKGRUNNSINFORMASJON_MAKS_TEGN } from '../../../model/PameldingFormValues.ts'
-import { getFeilmeldingIngenEndring } from '../../../utils/displayText.ts'
+import { getFeilmeldingIngenEndringTekst } from '../../../utils/displayText.ts'
 import { Endringsmodal } from '../modal/Endringsmodal.tsx'
 import { validerDeltakerKanEndres } from '../../../utils/endreDeltakelse.ts'
 
@@ -41,7 +41,7 @@ export const EndreBakgrunnsinfoModal = ({
 
     validerDeltakerKanEndres(pamelding)
     if (bakgrunnsinformasjon === pamelding.bakgrunnsinformasjon) {
-      throw new Error(getFeilmeldingIngenEndring(false))
+      throw new Error(getFeilmeldingIngenEndringTekst(false))
     }
 
     return {

--- a/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndreInnholdModal.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndreInnholdModal.tsx
@@ -22,7 +22,10 @@ import {
   BESKRIVELSE_ANNET_MAX_TEGN,
   generateValgtInnholdKoder
 } from '../../../model/PameldingFormValues'
-import { getFeilmeldingIngenEndring } from '../../../utils/displayText.ts'
+import {
+  getFeilmeldingIngenEndring,
+  getFeilmeldingIngenEndringTekst
+} from '../../../utils/displayText.ts'
 import { generateInnholdFromResponse } from '../../../utils/pamelding-form-utils'
 import { Endringsmodal } from '../modal/Endringsmodal.tsx'
 import { validerDeltakerKanEndres } from '../../../utils/endreDeltakelse.ts'
@@ -105,7 +108,11 @@ export const EndreInnholdModal = ({
         (!visCheckbokser &&
           innholdsTekst === getAnnetBeskrivelseFraInnhold(innhold))
       ) {
-        throw new Error(getFeilmeldingIngenEndring(false))
+        throw new Error(
+          pamelding.deltakerliste.tiltakstype === Tiltakstype.VASV
+            ? getFeilmeldingIngenEndringTekst(false)
+            : getFeilmeldingIngenEndring(false)
+        )
       }
 
       const endring: EndreInnholdRequest = {

--- a/apps/nav-veileders-flate/src/utils/displayText.ts
+++ b/apps/nav-veileders-flate/src/utils/displayText.ts
@@ -1,12 +1,19 @@
 import { DeltakerStatusAarsakType } from 'deltaker-flate-common'
 import { PameldingResponse } from '../api/data/pamelding.ts'
 
+const hvisForslagTekst =
+  '\n\nDersom du ikke ønsker å gjøre endringer i tiltaket, må du avvise forslaget fra tiltaksarrangør øverst i skjemaet.'
+
+export const getFeilmeldingIngenEndringTekst = (harForslag: boolean) => {
+  const feilmelding =
+    'Innholdet i skjemaet medfører ingen endringer i deltakelsen på tiltaket.\nFor å lagre må du endre på beskrivelsen.'
+  return harForslag ? `${feilmelding}${hvisForslagTekst}` : feilmelding
+}
+
 export const getFeilmeldingIngenEndring = (harForslag: boolean) => {
   const feilmelding =
-    'Innholdet i skjemaet medfører ingen endringer i deltakelsen på tiltaket. \nFor å lagre må minst ett felt i skjemaet være ulikt nåværende deltakelse.'
-  return harForslag
-    ? `${feilmelding}\n\nDersom du ikke ønsker å gjøre endringer i tiltaket, må du avvise forslaget fra tiltaksarrangør øverst i skjemaet.`
-    : feilmelding
+    'Innholdet i skjemaet medfører ingen endringer i deltakelsen på tiltaket.\nFor å lagre må minst ett felt i skjemaet være ulikt nåværende deltakelse.'
+  return harForslag ? `${feilmelding}${hvisForslagTekst}` : feilmelding
 }
 
 export const FEILMELDING_15_DAGER_SIDEN =


### PR DESCRIPTION
https://trello.com/c/nrOO71lR/2013-tilpasse-feilmelding-validering-p%C3%A5-endre-innhold-modal-p%C3%A5-vta