### PR TITLE
Fiks feilregistrert og legg til info tekst for fullført og avbrutt status

### DIFF
--- a/apps/nav-veileders-flate/src/pages/TiltakPage.tsx
+++ b/apps/nav-veileders-flate/src/pages/TiltakPage.tsx
@@ -21,13 +21,12 @@ export const TiltakPage = () => {
       <Tilbakeknapp />
       <div className="flex flex-col gap-4 xl:flex-row-reverse">
         <ForNAVAnsatt className="xl:max-w-[412px] w-full" />
-        {pamelding.status.type === DeltakerStatusType.FEILREGISTRERT &&
-        pamelding.vedtaksinformasjon ? (
+        {pamelding.status.type === DeltakerStatusType.FEILREGISTRERT ? (
           <FeilregistrertInfo
             className="w-full"
             dialogUrl={DIALOG_URL}
             tiltakOgStedTekst={tiltakOgStedTekst}
-            meldtPaDato={pamelding.vedtaksinformasjon.fattet}
+            meldtPaDato={pamelding.vedtaksinformasjon?.fattet}
             feilregistrertDato={pamelding.status.gyldigFra}
           />
         ) : (

--- a/packages/deltaker-flate-common/components/DeltakerStatusInfoTekst.tsx
+++ b/packages/deltaker-flate-common/components/DeltakerStatusInfoTekst.tsx
@@ -27,7 +27,9 @@ export const skalViseDeltakerStatusInfoTekst = (status: DeltakerStatusType) => {
     status === DeltakerStatusType.IKKE_AKTUELL ||
     status === DeltakerStatusType.VURDERES ||
     status === DeltakerStatusType.VENTELISTE ||
-    status === DeltakerStatusType.SOKT_INN
+    status === DeltakerStatusType.SOKT_INN ||
+    status === DeltakerStatusType.FULLFORT ||
+    status === DeltakerStatusType.AVBRUTT
   )
 }
 
@@ -52,6 +54,9 @@ const getInfoTekst = (
       return `Du er søkt inn på arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
     case DeltakerStatusType.VENTELISTE:
       return `Du er satt på venteliste for arbeidsmarkedstiltaket: ${tiltakOgStedTekst}.`
+    case DeltakerStatusType.FULLFORT:
+    case DeltakerStatusType.AVBRUTT:
+      return `Du deltok på ${tiltakOgStedTekst}.`
   }
 }
 

--- a/packages/deltaker-flate-common/components/FeilregistrertInfo.tsx
+++ b/packages/deltaker-flate-common/components/FeilregistrertInfo.tsx
@@ -39,9 +39,11 @@ export const FeilregistrertInfo = ({
         feil.
       </BodyShort>
 
-      <BodyShort className="mt-4">
-        {`Meldt på: ${formatDateWithMonthName(meldtPaDato)}`}
-      </BodyShort>
+      {meldtPaDato && (
+        <BodyShort className="mt-4">
+          {`Meldt på: ${formatDateWithMonthName(meldtPaDato)}`}
+        </BodyShort>
+      )}
 
       <BodyShort className="mt-4">
         {`Feilen ble registrert: ${formatDateWithMonthName(feilregistrertDato)}`}

--- a/packages/deltaker-flate-common/components/historikk/HistorikkTiltakskoordinatorEndring.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkTiltakskoordinatorEndring.tsx
@@ -11,7 +11,6 @@ import {
 import { formatDate } from '../../utils/utils.ts'
 import { EndringTypeIkon } from '../EndringTypeIkon.tsx'
 import { HistorikkElement } from './HistorikkElement.tsx'
-import React from 'react'
 
 interface Props {
   tiltakskoordinatorEndring: EndringerFraTiltakskoordinator


### PR DESCRIPTION
https://trello.com/c/tQLpvGTy/2321-n%C3%A5r-status-er-fullf%C3%B8rt-og-avbrutt-s%C3%A5-mangler-det-en-ingress-setning-p%C3%A5-tiltakssiden