### PR TITLE
Legger til håndtering av feil når man gjør oppdatering på flere deltakere og en eller flere feiler

### DIFF
--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -27,6 +27,12 @@ export enum Vurderingstype {
   OPPFYLLER_IKKE_KRAVENE = 'OPPFYLLER_IKKE_KRAVENE'
 }
 
+export enum Feilkode {
+  UGYLDIG_STATE = 'UGYLDIG_STATE',
+  MIDLERTIDIG_FEIL = 'MIDLERTIDIG_FEIL',
+  UKJENT = 'UKJENT'
+}
+
 export const deltakerSchema = z.object({
   id: z.string().uuid(),
   fornavn: z.string(),
@@ -36,7 +42,8 @@ export const deltakerSchema = z.object({
   vurdering: z.nativeEnum(Vurderingstype).nullable(),
   beskyttelsesmarkering: z.array(z.nativeEnum(Beskyttelsesmarkering)),
   navEnhet: z.string().nullable(),
-  erManueltDeltMedArrangor: z.boolean()
+  erManueltDeltMedArrangor: z.boolean(),
+  feilkode: z.nativeEnum(Feilkode).nullable().optional()
 })
 
 export const deltakereSchema = z.array(deltakerSchema)

--- a/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.tsx
@@ -12,12 +12,6 @@ import {
   HandlingValg,
   useHandlingContext
 } from '../../context-providers/HandlingContext.tsx'
-import { useSorteringContext } from '../../context-providers/SorteringContext.tsx'
-import {
-  ScopedSortState,
-  SortKey,
-  useDeltakerSortering
-} from '../../hooks/useDeltakerSortering.tsx'
 import { getDeltakerUrl } from '../../navigation.ts'
 import { lagDeltakerNavnEtternavnForst } from '../../utils/utils.ts'
 import { kanVelges } from '../../utils/velgDeltakereUtils.ts'
@@ -29,6 +23,13 @@ import { Vurdering } from '../Vurdering.tsx'
 import { GiAvslagKnapp } from './GiAvslagKnapp.tsx'
 import { MarkerAlleCheckbox } from './MarkerAlleCheckbox.tsx'
 import { VelgDeltakerCheckbox } from './VelgDeltakerCheckbox.tsx'
+import {
+  ScopedSortState,
+  SortKey,
+  useDeltakerSortering
+} from '../../hooks/useDeltakerSortering.tsx'
+import { useSorteringContext } from '../../context-providers/SorteringContext.tsx'
+import { HandlingFullfortMedFeilAlert } from '../handling/HandlingFullfortMedFeilAlert.tsx'
 
 export const DeltakerlisteTabell = () => {
   const { deltakere, deltakerlisteDetaljer } = useDeltakerlisteContext()
@@ -228,6 +229,7 @@ export const DeltakerlisteTabell = () => {
         </Table.Body>
       </Table>
 
+      <HandlingFullfortMedFeilAlert />
       <HandlingFullfortAlert />
 
       {handlingValg && (

--- a/apps/tiltakskoordinator-flate/src/components/handling/DelMedArrangorModal.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/handling/DelMedArrangorModal.tsx
@@ -2,9 +2,13 @@ import { BodyShort } from '@navikt/ds-react'
 import { useState } from 'react'
 import { delDeltakereMedArrangor } from '../../api/api'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
-import { useHandlingContext } from '../../context-providers/HandlingContext'
+import {
+  HandlingValg,
+  useHandlingContext
+} from '../../context-providers/HandlingContext'
 import { HandlingModal } from './HandlingModal'
 import { getDeltakereOppdatert } from '../../utils/utils'
+import { lagInfoTekst } from './text-utils.ts'
 
 interface Props {
   open: boolean
@@ -14,8 +18,12 @@ interface Props {
 
 export const DelMedArrangorModal = ({ open, onClose, onSend }: Props) => {
   const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
-  const { valgteDeltakere, handlingValg, setHandlingUtfortText } =
-    useHandlingContext()
+  const {
+    valgteDeltakere,
+    handlingValg,
+    setHandlingUtfortText,
+    setHandlingFeiletText
+  } = useHandlingContext()
 
   const [error, setError] = useState<string | null>(null)
 
@@ -23,21 +31,32 @@ export const DelMedArrangorModal = ({ open, onClose, onSend }: Props) => {
     return null
   }
 
+  const onModalClose = () => {
+    onClose()
+    setError(null)
+  }
+
   const utforHandling = () => {
     return delDeltakereMedArrangor(
       deltakerlisteDetaljer.id,
       valgteDeltakere.map((it) => it.id)
     )
-      .then((oppdaterteDeltakere) => {
-        setDeltakere((deltakere) =>
-          getDeltakereOppdatert(deltakere, oppdaterteDeltakere)
+      .then((deltakereResult) => {
+        const feiledeDeltakere = deltakereResult.filter(
+          (deltaker) => deltaker.feilkode !== null
         )
-        setError(null)
+        setDeltakere((deltakere) =>
+          getDeltakereOppdatert(deltakere, deltakereResult)
+        )
         onSend()
 
-        setHandlingUtfortText(
-          `${valgteDeltakere.length} deltaker${valgteDeltakere.length === 1 ? '' : 'e'} ble delt med arrangør.`
+        const infoTekst = lagInfoTekst(
+          deltakereResult,
+          HandlingValg.TILDEL_PLASS
         )
+        if (feiledeDeltakere.length > 0) {
+          setHandlingFeiletText(infoTekst)
+        } else setHandlingUtfortText(infoTekst)
       })
       .catch(() => {
         setError('Kunne ikke dele med arrangør. Vennligst prøv igjen.')
@@ -47,7 +66,7 @@ export const DelMedArrangorModal = ({ open, onClose, onSend }: Props) => {
   return (
     <HandlingModal
       open={open}
-      onClose={onClose}
+      onClose={onModalClose}
       onUtforHandling={utforHandling}
       error={error}
     >

--- a/apps/tiltakskoordinator-flate/src/components/handling/HandlingFullfortMedFeilAlert.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/handling/HandlingFullfortMedFeilAlert.tsx
@@ -1,0 +1,25 @@
+import { Alert } from '@navikt/ds-react'
+import { useHandlingContext } from '../../context-providers/HandlingContext'
+
+export const HandlingFullfortMedFeilAlert = () => {
+  const { handlingFeiletText, setHandlingFeiletText } = useHandlingContext()
+
+  const onClose = () => {
+    setHandlingFeiletText(null)
+  }
+
+  if (!handlingFeiletText) return
+  return (
+    <div className="sticky bottom-32 left-0 right-0 mb-20">
+      <Alert
+        closeButton
+        variant="warning"
+        size="small"
+        className="m-auto mt-4"
+        onClose={onClose}
+      >
+        {handlingFeiletText}
+      </Alert>
+    </div>
+  )
+}

--- a/apps/tiltakskoordinator-flate/src/components/handling/SettPaVentelisteModal.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/handling/SettPaVentelisteModal.tsx
@@ -2,9 +2,13 @@ import { BodyShort } from '@navikt/ds-react'
 import { useState } from 'react'
 import { settDeltakerePaVenteliste } from '../../api/api'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
-import { useHandlingContext } from '../../context-providers/HandlingContext'
+import {
+  HandlingValg,
+  useHandlingContext
+} from '../../context-providers/HandlingContext'
 import { HandlingModal } from './HandlingModal'
-import { getDeltakereOppdatert } from '../../utils/utils'
+import { getDeltakereOppdatert } from '../../utils/utils.ts'
+import { lagInfoTekst } from './text-utils.ts'
 
 interface Props {
   open: boolean
@@ -14,8 +18,12 @@ interface Props {
 
 export const SettPaVentelisteModal = ({ open, onClose, onSend }: Props) => {
   const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
-  const { valgteDeltakere, handlingValg, setHandlingUtfortText } =
-    useHandlingContext()
+  const {
+    valgteDeltakere,
+    handlingValg,
+    setHandlingUtfortText,
+    setHandlingFeiletText
+  } = useHandlingContext()
 
   const [error, setError] = useState<string | null>(null)
 
@@ -23,21 +31,32 @@ export const SettPaVentelisteModal = ({ open, onClose, onSend }: Props) => {
     return null
   }
 
+  const onModalClose = () => {
+    onClose()
+    setError(null)
+  }
+
   const utforHandling = (): Promise<void> => {
     return settDeltakerePaVenteliste(
       deltakerlisteDetaljer.id,
       valgteDeltakere.map((it) => it.id)
     )
-      .then((oppdaterteDeltakere) => {
-        setDeltakere((deltakere) =>
-          getDeltakereOppdatert(deltakere, oppdaterteDeltakere)
+      .then((deltakereResult) => {
+        const feiledeDeltakere = deltakereResult.filter(
+          (deltaker) => deltaker.feilkode !== null
         )
-        setError(null)
+        setDeltakere((deltakere) =>
+          getDeltakereOppdatert(deltakere, deltakereResult)
+        )
         onSend()
 
-        setHandlingUtfortText(
-          `${valgteDeltakere.length} deltaker${valgteDeltakere.length === 1 ? '' : 'e'} ble satt på venteliste.`
+        const infoTekst = lagInfoTekst(
+          deltakereResult,
+          HandlingValg.SETT_PA_VENTELISTE
         )
+        if (feiledeDeltakere.length > 0) {
+          setHandlingFeiletText(infoTekst)
+        } else setHandlingUtfortText(infoTekst)
       })
       .catch(() => {
         setError('Kunne ikke sette på venteliste. Vennligst prøv igjen.')
@@ -47,7 +66,7 @@ export const SettPaVentelisteModal = ({ open, onClose, onSend }: Props) => {
   return (
     <HandlingModal
       open={open}
-      onClose={onClose}
+      onClose={onModalClose}
       onUtforHandling={utforHandling}
       error={error}
     >

--- a/apps/tiltakskoordinator-flate/src/components/handling/text-utils.ts
+++ b/apps/tiltakskoordinator-flate/src/components/handling/text-utils.ts
@@ -1,0 +1,44 @@
+import { Deltaker } from '../../api/data/deltakerliste.ts'
+import { HandlingValg } from '../../context-providers/HandlingContext.tsx'
+import { lagDeltakerNavn } from '../../utils/utils.ts'
+
+export const lagInfoTekst = (deltakere: Deltaker[], handling: HandlingValg) => {
+  const handlingstekst = getHandlingsTekst(handling)
+  const antallOppdaterte = deltakere.filter(
+    (deltaker) => deltaker.feilkode === null
+  ).length
+  const antallValgte = deltakere.length
+  const feiledeDeltakere = deltakere.filter(
+    (deltaker) => deltaker.feilkode !== null
+  )
+
+  if (feiledeDeltakere.length > 0) {
+    const navn = feiledeDeltakere
+      .map((deltaker) =>
+        lagDeltakerNavn(
+          deltaker.fornavn,
+          deltaker.mellomnavn,
+          deltaker.etternavn
+        )
+      )
+      .join(', ')
+    return `${antallOppdaterte} av ${antallValgte} deltakere ${handlingstekst}. ${navn} kunne ikke endres. Vennligst prøv igjen`
+  } else {
+    return `${antallOppdaterte} deltaker${antallOppdaterte === 1 ? '' : 'e'} ${handlingstekst}.`
+  }
+}
+
+const getHandlingsTekst = (handling: HandlingValg) => {
+  switch (handling) {
+    case HandlingValg.SETT_PA_VENTELISTE:
+      return 'ble satt på venteliste'
+    case HandlingValg.DEL_DELTAKERE:
+      return 'ble delt med arrangør'
+    case HandlingValg.GI_AVSLAG:
+      return 'fikk avslag'
+    case HandlingValg.TILDEL_PLASS:
+      return 'ble tildelt plass'
+    default:
+      throw Error(`Ikke støttet type ${handling}`)
+  }
+}

--- a/apps/tiltakskoordinator-flate/src/context-providers/HandlingContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/HandlingContext.tsx
@@ -15,6 +15,8 @@ export interface HandlingContextProps {
   setValgteDeltakere: React.Dispatch<React.SetStateAction<Deltaker[]>>
   handlingUtfortText: string | null
   setHandlingUtfortText: React.Dispatch<React.SetStateAction<string | null>>
+  handlingFeiletText: string | null
+  setHandlingFeiletText: React.Dispatch<React.SetStateAction<string | null>>
 }
 
 const HandlingContext = createContext<HandlingContextProps | undefined>(
@@ -43,6 +45,9 @@ const HandlingContextProvider = ({
   const [handlingUtfortText, setHandlingUtfortText] = useState<string | null>(
     null
   )
+  const [handlingFeiletText, setHandlingFeiletText] = useState<string | null>(
+    null
+  )
 
   const contextValue: HandlingContextProps = {
     handlingValg,
@@ -50,7 +55,9 @@ const HandlingContextProvider = ({
     handlingUtfortText,
     setHandlingValg,
     setValgteDeltakere,
-    setHandlingUtfortText
+    setHandlingUtfortText,
+    handlingFeiletText,
+    setHandlingFeiletText
   }
 
   return (

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
@@ -5,7 +5,11 @@ import {
 } from 'deltaker-flate-common'
 import { HttpResponse } from 'msw'
 import { DeltakerDetaljer } from '../api/data/deltaker.ts'
-import { Deltakere, DeltakerlisteDetaljer } from '../api/data/deltakerliste.ts'
+import {
+  Deltakere,
+  DeltakerlisteDetaljer,
+  Feilkode
+} from '../api/data/deltakerliste.ts'
 import {
   createMockDeltakere,
   createMockDeltakerlisteDetaljer,
@@ -107,8 +111,14 @@ export class MockHandler {
   settPaVenteliste(delteDeltakerIder: string[]) {
     const oppdaterteDeltakere = this.deltakere.map((deltaker) => {
       if (delteDeltakerIder.includes(deltaker.id)) {
-        deltaker.status.type = DeltakerStatusType.VENTELISTE
         deltaker.status.aarsak = null
+        deltaker.feilkode = [Feilkode.MIDLERTIDIG_FEIL, null][
+          ~~(Math.random() * 2)
+        ]
+        deltaker.status.type =
+          deltaker.feilkode !== null
+            ? DeltakerStatusType.VENTELISTE
+            : deltaker.status.type
       }
       return deltaker
     })


### PR DESCRIPTION


* Man får nå en egen alertstripe når noen feiler med info om hvilke deltakere som feilet
* Retter feil som gjør at den "vanlige" feil alertstripen vistes fortsatt når man åpnet vinduet igjen
https://trello.com/c/WMiV9I7v/2249-feilh%C3%A5ndtering-for-sett-p%C3%A5-venteliste-og-del-med-arrang%C3%B8r-og-tildelplass