### PR TITLE
Fix shadowdom css scoping

### DIFF
--- a/apps/tiltakskoordinator-flate/src/components/handling/HandlingerKnapp.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/handling/HandlingerKnapp.tsx
@@ -14,6 +14,7 @@ import {
   useHandlingContext
 } from '../../context-providers/HandlingContext'
 import { useFeatureToggles } from '../../hooks/useFeatureToggles.ts'
+import { useShadowDom } from '../../context-providers/ShadowDomContext'
 
 interface Props {
   onModalOpen: () => void
@@ -25,6 +26,7 @@ export const HandlingerKnapp = ({ onModalOpen, className }: Props) => {
   const { handlingValg, setHandlingValg, setValgteDeltakere } =
     useHandlingContext()
   const { erKometMasterForTiltak } = useFeatureToggles()
+  const { containerElement } = useShadowDom()
   const kometErMaster = erKometMasterForTiltak(
     deltakerlisteDetaljer.tiltakskode
   )
@@ -91,7 +93,7 @@ export const HandlingerKnapp = ({ onModalOpen, className }: Props) => {
       )}
 
       {handlingValg === null && (
-        <ActionMenu>
+        <ActionMenu rootElement={containerElement}>
           <ActionMenu.Trigger>
             <Button ref={handlingKnappRef} size="small">
               Handlinger
@@ -166,7 +168,7 @@ export const HandlingerKnapp = ({ onModalOpen, className }: Props) => {
                   <PlusCircleFillIcon
                     width="1.125rem"
                     height="1.125rem"
-                    style={{ rotate: '45deg' }}
+                    className="rotate-45"
                     aria-hidden
                     color="var(--a-orange-600)"
                   />

--- a/apps/tiltakskoordinator-flate/src/context-providers/ShadowDomContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/ShadowDomContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react'
+
+interface ShadowDomContextType {
+  shadowRoot: ShadowRoot | null
+  containerElement: HTMLElement | null
+}
+
+export const ShadowDomContext = createContext<ShadowDomContextType>({
+  shadowRoot: null,
+  containerElement: null
+})
+
+export const useShadowDom = () => {
+  const context = useContext(ShadowDomContext)
+  return context
+}

--- a/apps/tiltakskoordinator-flate/src/webComponentWrapper.tsx
+++ b/apps/tiltakskoordinator-flate/src/webComponentWrapper.tsx
@@ -3,6 +3,7 @@ import { createRoot, Root } from 'react-dom/client'
 import appCss from './app.css?inline'
 import { App } from './App.tsx'
 import { AppContextProvider } from './context-providers/AppContext.tsx'
+import { ShadowDomContext } from './context-providers/ShadowDomContext.tsx'
 import {
   APPLICATION_NAME,
   APPLICATION_WEB_COMPONENT_NAME
@@ -51,11 +52,15 @@ export class Deltakerliste extends HTMLElement {
 
     this.reactRoot = createRoot(this.root)
     this.reactRoot.render(
-      <div className="m-auto pt-4 min-h-screen max-w-[1920px]">
-        <AppContextProvider initialDeltakerlisteId={deltakerlisteId}>
-          <App />
-        </AppContextProvider>
-      </div>
+      <ShadowDomContext.Provider
+        value={{ shadowRoot, containerElement: this.root }}
+      >
+        <div className="m-auto pt-4 min-h-screen max-w-[1920px]">
+          <AppContextProvider initialDeltakerlisteId={deltakerlisteId}>
+            <App />
+          </AppContextProvider>
+        </div>
+      </ShadowDomContext.Provider>
     )
   }
 


### PR DESCRIPTION
`ActionMenu` åpner en portal på rot-noden hvis man ikke spesifiserer noe annet. Da havnet den utenfor shadowdomen og hadde ikke våre tailwind klasser tilgjengelig.