### PR TITLE
Gjør det mulig for veileder å endre sluttdato hvis sluttdato er under 2 mnd siden isteden for å gjøre det samme med status gyldigFra.

### DIFF
--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -163,7 +163,7 @@ export class MockHandler {
     return EMDASH
   }
 
-  getSluttdato(): string {
+  getSluttdato(): string | null {
     if (this.statusType === DeltakerStatusType.DELTAR) {
       const fremtidigDato = new Date()
       fremtidigDato.setDate(fremtidigDato.getDate() + 10)
@@ -175,7 +175,7 @@ export class MockHandler {
       this.statusType === DeltakerStatusType.AVBRUTT
     ) {
       const passertDato = new Date()
-      passertDato.setDate(passertDato.getDate() - 10)
+      passertDato.setDate(passertDato.getDate() + 61)
       return dayjs(passertDato).format('YYYY-MM-DD')
     }
     return EMDASH

--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -175,7 +175,7 @@ export class MockHandler {
       this.statusType === DeltakerStatusType.AVBRUTT
     ) {
       const passertDato = new Date()
-      passertDato.setDate(passertDato.getDate() + 61)
+      passertDato.setDate(passertDato.getDate() - 10)
       return dayjs(passertDato).format('YYYY-MM-DD')
     }
     return EMDASH

--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -163,7 +163,7 @@ export class MockHandler {
     return EMDASH
   }
 
-  getSluttdato(): string | null {
+  getSluttdato(): string {
     if (this.statusType === DeltakerStatusType.DELTAR) {
       const fremtidigDato = new Date()
       fremtidigDato.setDate(fremtidigDato.getDate() + 10)

--- a/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
+++ b/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
@@ -79,13 +79,13 @@ const skalViseEndreBakgrunnsinfoKnapp = (
 
 const skalViseEndreSluttdatoKnapp = (
   pamelding: PameldingResponse,
-  statusdato: Date,
   toMndSiden: Date
-) =>
-  deltakerHarSluttetEllerFullfort(pamelding.status.type) &&
-  statusdato > toMndSiden &&
-  pamelding.kanEndres
+) => {
+  const sluttdato = dateStrToNullableDate(pamelding.sluttdato)
+  if (!deltakerHarSluttetEllerFullfort(pamelding.status.type)) return false
 
+  return sluttdato! > toMndSiden && pamelding.kanEndres
+}
 const skalViseEndreSluttarsakKnapp = (
   pamelding: PameldingResponse,
   statusdato: Date,
@@ -167,7 +167,7 @@ export const getEndreDeltakelsesValg = (pamelding: PameldingResponse) => {
   if (pamelding.status.type === DeltakerStatusType.DELTAR) {
     valg.push(EndreDeltakelseType.AVSLUTT_DELTAKELSE)
   }
-  if (skalViseEndreSluttdatoKnapp(pamelding, statusdato, toMndSiden)) {
+  if (skalViseEndreSluttdatoKnapp(pamelding, toMndSiden)) {
     valg.push(EndreDeltakelseType.ENDRE_SLUTTDATO)
   }
   if (skalViseEndreSluttarsakKnapp(pamelding, statusdato, toMndSiden)) {

--- a/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
+++ b/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
@@ -199,7 +199,7 @@ export const validerDeltakerKanEndres = (deltaker: PameldingResponse) => {
       )
     }
     const toMndSiden = dayjs().subtract(2, 'months')
-    if (dayjs(deltaker.status.gyldigFra).isSameOrBefore(toMndSiden)) {
+    if (dayjs(deltaker.sluttdato).isSameOrBefore(toMndSiden)) {
       throw new Error(
         'Deltaker fikk avsluttende status for mer enn to måneder siden, og kan derfor ikke redigeres.'
       )


### PR DESCRIPTION

* For å rette feil med at mange deltakere har status HAR_SLUTTET og sluttdato langt fram i tid som skaper problemer i valps flate


https://trello.com/c/wqpgHXKF/2372-det-er-ikke-mulig-%C3%A5-endre-sluttdato-for-%C3%A5-rette-feil