### PR TITLE
Det skal være tillatt å endre oppstarsdato for deltakere som har fullført

### DIFF
--- a/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndreOppstartsdatoModal.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndreOppstartsdatoModal.tsx
@@ -6,7 +6,6 @@ import {
 } from '@navikt/ds-react'
 import dayjs from 'dayjs'
 import {
-  DeltakerStatusType,
   EndreDeltakelseType,
   Forslag,
   ForslagEndring,
@@ -41,6 +40,7 @@ import { VarighetField } from '../VarighetField.tsx'
 import { Endringsmodal } from '../modal/Endringsmodal.tsx'
 import {
   kanLeggeTilOppstartsdato,
+  kanEndreOppstartsdato,
   validerDeltakerKanEndres
 } from '../../../utils/endreDeltakelse.ts'
 
@@ -170,7 +170,7 @@ export const EndreOppstartsdatoModal = ({
         throw new Error(getFeilmeldingIngenEndring(forslag !== null))
       }
       validerDeltakerKanEndres(pamelding)
-      if (!harStatusSomKanEndreStartDato(pamelding.status.type)) {
+      if (!kanEndreOppstartsdato(pamelding)) {
         throw new Error(
           `Kan ikke endre oppstartsdato for deltaker med status ${getDeltakerStatusDisplayText(pamelding.status.type)}.`
         )
@@ -314,8 +314,3 @@ function getDatoer(deltaker: PameldingResponse, forslag: Forslag | null) {
     )
   }
 }
-
-const harStatusSomKanEndreStartDato = (statusType: DeltakerStatusType) =>
-  statusType === DeltakerStatusType.VENTER_PA_OPPSTART ||
-  statusType === DeltakerStatusType.DELTAR ||
-  statusType === DeltakerStatusType.HAR_SLUTTET


### PR DESCRIPTION
* samler implementasjon som brukes for om valget skal dukke opp under "endre deltakelse" og validering når man trykker på Lagre
* samler samtidig sjekken på at deltakelsen må være nyere enn 2 mnd gammel


Skal ta en titt på om de andre valgene har samme problematikk også men vil merge denne først iom at det er flere oppgaver som toucher samme kode
https://trello.com/c/ChkEL3UN/2375-tillate-%C3%A5-endre-oppstartsdato-p%C3%A5-deltakelse-som-er-fullf%C3%B8rt-og-avbrutt