### PR TITLE
Fjern “Del med arrangør”-info 

### DIFF
--- a/apps/nav-veileders-flate/src/components/pamelding/standard/PameldingForm.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/standard/PameldingForm.tsx
@@ -87,7 +87,7 @@ export const PameldingForm = ({ className, focusOnOpen }: Props) => {
             erEnkeltplass={deltaker.deltakerliste.erEnkeltplass}
             startdato={deltaker.deltakerliste.startdato}
             sluttdato={deltaker.deltakerliste.sluttdato}
-            visDelMedArrangorInfo
+            visDelMedArrangorInfo={false}
           />
 
           {harBakgrunnsinfo(tiltakskode) && (

--- a/apps/nav-veileders-flate/src/components/pamelding/standard/PameldingForm.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/standard/PameldingForm.tsx
@@ -87,7 +87,6 @@ export const PameldingForm = ({ className, focusOnOpen }: Props) => {
             erEnkeltplass={deltaker.deltakerliste.erEnkeltplass}
             startdato={deltaker.deltakerliste.startdato}
             sluttdato={deltaker.deltakerliste.sluttdato}
-            visDelMedArrangorInfo={false}
           />
 
           {harBakgrunnsinfo(tiltakskode) && (

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.tsx
@@ -68,7 +68,6 @@ export const UtkastDeltaker = () => {
         startdato={deltaker.deltakerliste.startdato}
         sluttdato={deltaker.deltakerliste.sluttdato}
         size="small"
-        visDelMedArrangorInfo={false}
       />
 
       <Oppmotested

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.tsx
@@ -68,7 +68,7 @@ export const UtkastDeltaker = () => {
         startdato={deltaker.deltakerliste.startdato}
         sluttdato={deltaker.deltakerliste.sluttdato}
         size="small"
-        visDelMedArrangorInfo
+        visDelMedArrangorInfo={false}
       />
 
       <Oppmotested

--- a/packages/deltaker-flate-common/components/OmKurset.tsx
+++ b/packages/deltaker-flate-common/components/OmKurset.tsx
@@ -9,7 +9,6 @@ import {
   erOpplaringstiltak,
   formatDate,
   formatDateWithMonthName,
-  kanDeleDeltakerMedArrangorForVurdering,
   kreverGodkjenningForPamelding
 } from '../utils/utils'
 
@@ -23,7 +22,6 @@ interface Props {
   sluttdato: Date | null
   size?: 'medium' | 'small'
   headingLevel?: 2 | 3 | 4
-  visDelMedArrangorInfo?: boolean
   className?: string
 }
 
@@ -37,7 +35,6 @@ export const OmKurset = ({
   sluttdato,
   headingLevel,
   size,
-  visDelMedArrangorInfo,
   className
 }: Props) => {
   const erTiltakSomSkalViseOmKurset =
@@ -132,26 +129,6 @@ export const OmKurset = ({
                   Du kan få avslag.
                 </List.Item>
               </List>
-
-              {kanDeleDeltakerMedArrangorForVurdering(
-                pameldingstype,
-                tiltakskode,
-                erEnkeltplass
-              ) &&
-                visDelMedArrangorInfo && (
-                  <>
-                    <BodyLong size="small" className="mt-4">
-                      For å avgjøre hvem som skal få plass, kan Nav be om hjelp
-                      til vurdering fra arrangøren av kurset. Arrangør eller
-                      koordinator hos Nav vil kontakte deg hvis det er behov for
-                      et møte.
-                    </BodyLong>
-                    <BodyLong size="small" className="mt-4">
-                      Du vil få beskjed dersom det oversendes informasjon til
-                      arrangør.
-                    </BodyLong>
-                  </>
-                )}
 
               <div className="flex mt-6">
                 <Label className="mr-2">Kurset starter: </Label>


### PR DESCRIPTION
## Pull request overview
Denne PR-en skjuler visningen av “Del med arrangør”-informasjon i kladd- og utkastflyten ved å eksplisitt skru av visningen i OmKurset-komponenten der den tidligere ble vist.

https://trello.com/c/eRg8zHmR/247-fjerne-tekst-i-kladd-og-utkast-felles-oppstart

## Changes:

Setter visDelMedArrangorInfo={false} i utkastvisning (UtkastDeltaker).
Setter visDelMedArrangorInfo={false} i kladd-/påmeldingsskjemaet (PameldingForm).
