### PR TITLE
Lagt til ny kolonne soktInnDato i tiltakskoordinators deltakerliste

### DIFF
--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -47,6 +47,7 @@ export const deltakerSchema = z.object({
   erNyDeltaker: z.boolean(),
   harOppdateringFraNav: z.boolean(),
   kanEndres: z.boolean(),
+  soktInnDato: nullableDateSchema,
   startdato: nullableDateSchema,
   sluttdato: nullableDateSchema
 })

--- a/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.tsx
@@ -119,7 +119,7 @@ export const DeltakerlisteTabell = () => {
       )}
 
       <div
-        className="w-full overflow-x-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        className="w-full overflow-x-auto focus-visible:outline focus-visible:outline-offset-2"
         // tabIndex for keyboard-scrolling; region role for screen readers
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
@@ -154,6 +154,10 @@ export const DeltakerlisteTabell = () => {
               )}
               <TableHeaderCell label="Navn" sortKey={SortKey.NAVN} />
               <TableHeaderCell label="Nav-enhet" sortKey={SortKey.NAV_ENHET} />
+              <TableHeaderCell
+                label="Søkt inn"
+                sortKey={SortKey.SOKT_INN_DATO}
+              />
               {erLopendeOppstart && (
                 <>
                   <TableHeaderCell label="Start" sortKey={SortKey.START_DATO} />
@@ -232,6 +236,8 @@ export const DeltakerlisteTabell = () => {
                     text={deltaker.navEnhet}
                     className="min-w-32"
                   />
+
+                  <TableDataCell text={formatDate(deltaker.soktInnDato)} />
 
                   {erLopendeOppstart && (
                     <>

--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
@@ -80,6 +80,13 @@ export const sorterDeltakere = (
     }
 
     if (sort) {
+      const aVal = a[sort.orderBy]
+      const bVal = b[sort.orderBy]
+
+      if (aVal == null && bVal == null) return 0
+      if (aVal == null) return 1
+      if (bVal == null) return -1
+
       return sort.direction === 'ascending'
         ? comparator(b, a, sort.orderBy)
         : comparator(a, b, sort.orderBy)

--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
@@ -11,6 +11,7 @@ export enum SortKey {
   NAV_ENHET = 'navEnhet',
   STATUS = 'status',
   VURDERING = 'vurdering',
+  SOKT_INN_DATO = 'soktInnDato',
   START_DATO = 'startdato',
   SLUTT_DATO = 'sluttdato'
 }

--- a/apps/tiltakskoordinator-flate/src/mocks/mockData.tsx
+++ b/apps/tiltakskoordinator-flate/src/mocks/mockData.tsx
@@ -116,6 +116,7 @@ export const createMockDeltaker = (
     erManueltDeltMedArrangor: !!vurdering,
     beskyttelsesmarkering,
     navEnhet,
+    soktInnDato: faker.date.past(),
     startdato: faker.date.past(),
     sluttdato: faker.date.future(),
     navVeileder: {
@@ -270,6 +271,7 @@ export const lagMockDeltaker = (): Deltaker => {
     erNyDeltaker: false,
     harOppdateringFraNav: false,
     kanEndres: true,
+    soktInnDato: null,
     startdato: null,
     sluttdato: null
   }


### PR DESCRIPTION
## Trello card
https://trello.com/c/2SKhphNX

## Important
Avhenger av https://github.com/navikt/amt-deltakelser/pull/154

## Description
Legger til nytt felt/kolonne for søknadsdato (soktInnDato) i tiltakskoordinators deltakerliste, slik at datoen kan vises og sorteres på i tabellen.

Changes:

Utvider deltaker-dataschemaet med soktInnDato.
Legger til ny tabellkolonne “Søkt inn” og tilhørende sorteringsnøkkel.
Oppdaterer mock-data til å inkludere soktInnDato.