### PR TITLE
Lagt til refetch i filter for tiltakskoordinators deltakerliste

### DIFF
--- a/apps/tiltakskoordinator-flate/package.json
+++ b/apps/tiltakskoordinator-flate/package.json
@@ -26,6 +26,7 @@
     "@navikt/ds-css": "^8.10.3",
     "@navikt/ds-react": "^8.10.3",
     "@navikt/ds-tailwind": "^8.10.3",
+    "@tanstack/react-query": "^5.100.6",
     "dayjs": "^1.11.20",
     "deltaker-flate-common": "workspace:*",
     "msw": "^2.13.6",

--- a/apps/tiltakskoordinator-flate/src/App.tsx
+++ b/apps/tiltakskoordinator-flate/src/App.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import nb from 'dayjs/locale/nb'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 import PrBanner from './components/demo-banner/PrBanner.tsx'
 import { useAppContext } from './context-providers/AppContext.tsx'
@@ -9,6 +10,7 @@ import { SorteringContextProvider } from './context-providers/SorteringContext.t
 import { AppRoutes } from './Routes.tsx'
 import { isPrEnv, useMock } from './utils/environment-utils.ts'
 import DemoBanner from './components/demo-banner/DemoBanner.tsx'
+import { queryClient } from './queryClient.ts'
 
 dayjs.locale(nb)
 
@@ -16,7 +18,7 @@ export const App = () => {
   const { setDeltakerlisteId } = useAppContext()
 
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       {isPrEnv && <PrBanner setDeltakerlisteId={setDeltakerlisteId} />}
       {useMock && <DemoBanner />}
 
@@ -29,6 +31,6 @@ export const App = () => {
           </SorteringContextProvider>
         </FilterContextProvider>
       </HandlingContextProvider>
-    </>
+    </QueryClientProvider>
   )
 }

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -76,6 +76,7 @@ export const DeltakerListeGuard = () => {
 
       {deltakerlisteDetaljer && (
         <DeltakerlisteContextProvider
+          key={deltakerlisteDetaljer.id}
           initialDeltakerlisteDetaljer={deltakerlisteDetaljer}
           initialDeltakere={[]}
           initialStatusCounts={filterCounts.statusCounts}

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -53,7 +53,8 @@ export const DeltakerListeGuard = () => {
       ? { statusCounts: {}, handlingCounts: {} }
       : filterCountsQuery.data
 
-  const visFilterCountsFeil = !!filterCountsQuery.error
+  const visFilterCountsFeil =
+    !!filterCountsQuery.error || typeof filterCountsQuery.data === 'string'
 
   return (
     <>

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -53,6 +53,8 @@ export const DeltakerListeGuard = () => {
       ? { statusCounts: {}, handlingCounts: {} }
       : filterCountsQuery.data
 
+  const visFilterCountsFeil = !!filterCountsQuery.error
+
   return (
     <>
       {deltakerlisteDetaljerQuery.isLoading && (
@@ -78,6 +80,14 @@ export const DeltakerListeGuard = () => {
           initialStatusCounts={filterCounts.statusCounts}
           initialHandlingCounts={filterCounts.handlingCounts}
         >
+          {visFilterCountsFeil && (
+            <div className="px-4 pt-4">
+              <Alert variant="warning" size="small">
+                Kunne ikke hente filtertellinger. Tellingene kan være
+                ufullstendige.
+              </Alert>
+            </div>
+          )}
           <DemoStatusInnstillinger />
           <DeltakerlistePage />
         </DeltakerlisteContextProvider>

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -2,13 +2,18 @@ import { Alert, Heading, Loader } from '@navikt/ds-react'
 import { DeferredFetchState, useDeferredFetch } from 'deltaker-flate-common'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { getDeltakere, getDeltakerlisteDetaljer } from './api/api'
+import {
+  getDeltakere,
+  getDeltakerlisteDetaljer,
+  getDeltakerStatusCounts
+} from './api/api'
 import { Deltakere } from './api/data/deltakerliste'
 import { DemoStatusInnstillinger } from './components/demo-banner/DemoStatusInnstillinger'
 import { useAppContext } from './context-providers/AppContext'
 import { DeltakerlisteContextProvider } from './context-providers/DeltakerlisteContext'
 import { DEFAULT_STATUS_FILTERS } from './context-providers/FilterContext'
 import { DeltakerlistePage } from './pages/DeltakerlistePage'
+import { getFilterStatuser } from './utils/filter-deltakerliste'
 import { handterTilgangsFeil, isTilgangsFeil } from './utils/tilgangsFeil'
 
 export const DeltakerListeGuard = () => {
@@ -29,12 +34,33 @@ export const DeltakerListeGuard = () => {
     doFetch: doFetchDeltakere
   } = useDeferredFetch(getDeltakere)
 
+  const { data: statusCountsResponse, doFetch: doFetchStatusCounts } =
+    useDeferredFetch(getDeltakerStatusCounts)
+
   const fetchDeltakerliste = async () => {
+    const detaljer = await doFetchDeltakelisteDetaljer(deltakerlisteId)
+
+    if (!detaljer) {
+      return
+    }
+
+    const statuserForVisning = [
+      ...new Set(
+        getFilterStatuser(
+          detaljer.oppstartstype,
+          detaljer.pameldingstype,
+          detaljer.tiltakskode
+        )
+      )
+    ]
+
     await Promise.allSettled([
       doFetchDeltakere(deltakerlisteId, {
         statuser: DEFAULT_STATUS_FILTERS
       }),
-      doFetchDeltakelisteDetaljer(deltakerlisteId)
+      doFetchStatusCounts(deltakerlisteId, {
+        statuser: statuserForVisning
+      })
     ])
   }
 
@@ -80,6 +106,11 @@ export const DeltakerListeGuard = () => {
         <DeltakerlisteContextProvider
           initialDeltakerlisteDetaljer={deltakerlisteDetaljer}
           initialDeltakere={deltakere}
+          initialStatusCounts={
+            typeof statusCountsResponse === 'string' || !statusCountsResponse
+              ? {}
+              : statusCountsResponse
+          }
         >
           <DemoStatusInnstillinger />
           <DeltakerlistePage />

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -53,6 +53,9 @@ export const DeltakerListeGuard = () => {
       ? { statusCounts: {}, handlingCounts: {} }
       : filterCountsQuery.data
 
+  const filterCountsLaster =
+    filterCountsQuery.isLoading && !filterCountsQuery.data
+
   const visFilterCountsFeil =
     !!filterCountsQuery.error || typeof filterCountsQuery.data === 'string'
 
@@ -81,6 +84,7 @@ export const DeltakerListeGuard = () => {
           initialDeltakere={[]}
           initialStatusCounts={filterCounts.statusCounts}
           initialHandlingCounts={filterCounts.handlingCounts}
+          initialFilterCountsLaster={filterCountsLaster}
         >
           {visFilterCountsFeil && (
             <div className="px-4 pt-4">

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -7,6 +7,7 @@ import { Deltakere } from './api/data/deltakerliste'
 import { DemoStatusInnstillinger } from './components/demo-banner/DemoStatusInnstillinger'
 import { useAppContext } from './context-providers/AppContext'
 import { DeltakerlisteContextProvider } from './context-providers/DeltakerlisteContext'
+import { DEFAULT_STATUS_FILTERS } from './context-providers/FilterContext'
 import { DeltakerlistePage } from './pages/DeltakerlistePage'
 import { handterTilgangsFeil, isTilgangsFeil } from './utils/tilgangsFeil'
 
@@ -28,14 +29,18 @@ export const DeltakerListeGuard = () => {
     doFetch: doFetchDeltakere
   } = useDeferredFetch(getDeltakere)
 
-  const fetchDeltakerliste = () => {
-    doFetchDeltakere(deltakerlisteId)
-    doFetchDeltakelisteDetaljer(deltakerlisteId)
+  const fetchDeltakerliste = async () => {
+    await Promise.allSettled([
+      doFetchDeltakere(deltakerlisteId, {
+        statuser: DEFAULT_STATUS_FILTERS
+      }),
+      doFetchDeltakelisteDetaljer(deltakerlisteId)
+    ])
   }
 
   useEffect(() => {
     if (deltakerlisteId.length > 0) {
-      fetchDeltakerliste()
+      void fetchDeltakerliste()
     }
   }, [deltakerlisteId])
 

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -1,13 +1,12 @@
 import { Alert, Heading, Loader } from '@navikt/ds-react'
-import { DeferredFetchState, useDeferredFetch } from 'deltaker-flate-common'
-import { useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   getDeltakere,
   getDeltakerlisteDetaljer,
   getDeltakerStatusCounts
 } from './api/api'
-import { Deltakere } from './api/data/deltakerliste'
 import { DemoStatusInnstillinger } from './components/demo-banner/DemoStatusInnstillinger'
 import { useAppContext } from './context-providers/AppContext'
 import { DeltakerlisteContextProvider } from './context-providers/DeltakerlisteContext'
@@ -20,73 +19,72 @@ export const DeltakerListeGuard = () => {
   const { deltakerlisteId } = useAppContext()
   const navigate = useNavigate()
 
-  const {
-    data: deltakerlisteDetaljer,
-    state: stateDeltakerlisteDetaljer,
-    error: errorDeltakerlisteDetaljer,
-    doFetch: doFetchDeltakelisteDetaljer
-  } = useDeferredFetch(getDeltakerlisteDetaljer)
+  const deltakerlisteDetaljerQuery = useQuery({
+    queryKey: ['deltakerlisteDetaljer', deltakerlisteId],
+    queryFn: () => getDeltakerlisteDetaljer(deltakerlisteId),
+    enabled: deltakerlisteId.length > 0
+  })
 
-  const {
-    data: deltakereResponse,
-    state: stateDeltakere,
-    error: errorDeltakere,
-    doFetch: doFetchDeltakere
-  } = useDeferredFetch(getDeltakere)
+  const deltakereQuery = useQuery({
+    queryKey: ['deltakereInit', deltakerlisteId],
+    queryFn: () =>
+      getDeltakere(deltakerlisteId, {
+        statuser: DEFAULT_STATUS_FILTERS
+      }),
+    enabled: deltakerlisteId.length > 0
+  })
 
-  const { data: statusCountsResponse, doFetch: doFetchStatusCounts } =
-    useDeferredFetch(getDeltakerStatusCounts)
-
-  const fetchDeltakerliste = async () => {
-    const detaljer = await doFetchDeltakelisteDetaljer(deltakerlisteId)
-
-    if (!detaljer) {
-      return
+  const statuserForVisning = useMemo(() => {
+    if (!deltakerlisteDetaljerQuery.data) {
+      return []
     }
 
-    const statuserForVisning = [
+    return [
       ...new Set(
         getFilterStatuser(
-          detaljer.oppstartstype,
-          detaljer.pameldingstype,
-          detaljer.tiltakskode
+          deltakerlisteDetaljerQuery.data.oppstartstype,
+          deltakerlisteDetaljerQuery.data.pameldingstype,
+          deltakerlisteDetaljerQuery.data.tiltakskode
         )
       )
     ]
+  }, [deltakerlisteDetaljerQuery.data])
 
-    await Promise.allSettled([
-      doFetchDeltakere(deltakerlisteId, {
-        statuser: DEFAULT_STATUS_FILTERS
-      }),
-      doFetchStatusCounts(deltakerlisteId, {
+  const filterCountsQuery = useQuery({
+    queryKey: ['deltakerFilterCounts', deltakerlisteId, statuserForVisning],
+    queryFn: () =>
+      getDeltakerStatusCounts(deltakerlisteId, {
         statuser: statuserForVisning
-      })
-    ])
-  }
+      }),
+    enabled: deltakerlisteId.length > 0 && statuserForVisning.length > 0
+  })
 
-  useEffect(() => {
-    if (deltakerlisteId.length > 0) {
-      void fetchDeltakerliste()
-    }
-  }, [deltakerlisteId])
+  const deltakerlisteDetaljer = deltakerlisteDetaljerQuery.data
+  const deltakereResponse = deltakereQuery.data
 
-  if (isTilgangsFeil(deltakereResponse)) {
+  if (deltakereResponse && isTilgangsFeil(deltakereResponse)) {
     handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
   }
 
   const visFeilmelding =
-    errorDeltakerlisteDetaljer ||
-    errorDeltakere ||
-    (stateDeltakerlisteDetaljer === DeferredFetchState.RESOLVED &&
-      !deltakerlisteDetaljer) ||
-    (stateDeltakere === DeferredFetchState.RESOLVED && !deltakereResponse)
+    deltakerlisteDetaljerQuery.error ||
+    deltakereQuery.error ||
+    (deltakerlisteDetaljerQuery.isSuccess && !deltakerlisteDetaljer) ||
+    (deltakereQuery.isSuccess && !deltakereResponse)
 
-  const deltakere: Deltakere | null = deltakereResponse as Deltakere | null
+  const deltakere =
+    !deltakereResponse || isTilgangsFeil(deltakereResponse)
+      ? null
+      : deltakereResponse
+
+  const filterCounts =
+    typeof filterCountsQuery.data === 'string' || !filterCountsQuery.data
+      ? { statusCounts: {}, handlingCounts: {} }
+      : filterCountsQuery.data
 
   return (
     <>
-      {(stateDeltakerlisteDetaljer === DeferredFetchState.LOADING ||
-        stateDeltakere === DeferredFetchState.LOADING) && (
+      {(deltakerlisteDetaljerQuery.isLoading || deltakereQuery.isLoading) && (
         <div className="flex justify-center items-center h-screen">
           <Loader size="3xlarge" title="Venter..." />
         </div>
@@ -106,11 +104,8 @@ export const DeltakerListeGuard = () => {
         <DeltakerlisteContextProvider
           initialDeltakerlisteDetaljer={deltakerlisteDetaljer}
           initialDeltakere={deltakere}
-          initialStatusCounts={
-            typeof statusCountsResponse === 'string' || !statusCountsResponse
-              ? {}
-              : statusCountsResponse
-          }
+          initialStatusCounts={filterCounts.statusCounts}
+          initialHandlingCounts={filterCounts.handlingCounts}
         >
           <DemoStatusInnstillinger />
           <DeltakerlistePage />

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -1,36 +1,19 @@
 import { Alert, Heading, Loader } from '@navikt/ds-react'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
-import {
-  getDeltakere,
-  getDeltakerlisteDetaljer,
-  getDeltakerStatusCounts
-} from './api/api'
+import { getDeltakerlisteDetaljer, getDeltakerStatusCounts } from './api/api'
 import { DemoStatusInnstillinger } from './components/demo-banner/DemoStatusInnstillinger'
 import { useAppContext } from './context-providers/AppContext'
 import { DeltakerlisteContextProvider } from './context-providers/DeltakerlisteContext'
-import { DEFAULT_STATUS_FILTERS } from './context-providers/FilterContext'
 import { DeltakerlistePage } from './pages/DeltakerlistePage'
 import { getFilterStatuser } from './utils/filter-deltakerliste'
-import { handterTilgangsFeil, isTilgangsFeil } from './utils/tilgangsFeil'
 
 export const DeltakerListeGuard = () => {
   const { deltakerlisteId } = useAppContext()
-  const navigate = useNavigate()
 
   const deltakerlisteDetaljerQuery = useQuery({
     queryKey: ['deltakerlisteDetaljer', deltakerlisteId],
     queryFn: () => getDeltakerlisteDetaljer(deltakerlisteId),
-    enabled: deltakerlisteId.length > 0
-  })
-
-  const deltakereQuery = useQuery({
-    queryKey: ['deltakereInit', deltakerlisteId],
-    queryFn: () =>
-      getDeltakere(deltakerlisteId, {
-        statuser: DEFAULT_STATUS_FILTERS
-      }),
     enabled: deltakerlisteId.length > 0
   })
 
@@ -60,22 +43,10 @@ export const DeltakerListeGuard = () => {
   })
 
   const deltakerlisteDetaljer = deltakerlisteDetaljerQuery.data
-  const deltakereResponse = deltakereQuery.data
-
-  if (deltakereResponse && isTilgangsFeil(deltakereResponse)) {
-    handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
-  }
 
   const visFeilmelding =
     deltakerlisteDetaljerQuery.error ||
-    deltakereQuery.error ||
-    (deltakerlisteDetaljerQuery.isSuccess && !deltakerlisteDetaljer) ||
-    (deltakereQuery.isSuccess && !deltakereResponse)
-
-  const deltakere =
-    !deltakereResponse || isTilgangsFeil(deltakereResponse)
-      ? null
-      : deltakereResponse
+    (deltakerlisteDetaljerQuery.isSuccess && !deltakerlisteDetaljer)
 
   const filterCounts =
     typeof filterCountsQuery.data === 'string' || !filterCountsQuery.data
@@ -84,7 +55,7 @@ export const DeltakerListeGuard = () => {
 
   return (
     <>
-      {(deltakerlisteDetaljerQuery.isLoading || deltakereQuery.isLoading) && (
+      {deltakerlisteDetaljerQuery.isLoading && (
         <div className="flex justify-center items-center h-screen">
           <Loader size="3xlarge" title="Venter..." />
         </div>
@@ -100,10 +71,10 @@ export const DeltakerListeGuard = () => {
         </div>
       )}
 
-      {deltakerlisteDetaljer && deltakere && (
+      {deltakerlisteDetaljer && (
         <DeltakerlisteContextProvider
           initialDeltakerlisteDetaljer={deltakerlisteDetaljer}
-          initialDeltakere={deltakere}
+          initialDeltakere={[]}
           initialStatusCounts={filterCounts.statusCounts}
           initialHandlingCounts={filterCounts.handlingCounts}
         >

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -71,7 +71,7 @@ export const DeltakerListeGuard = () => {
         <div id="maincontent" role="main" tabIndex={-1}>
           <Alert variant="error" className="mt-4">
             <Heading spacing size="small" level="3">
-              Kunne ikke hente deltakere. Vennligst prøv igjen.
+              Kunne ikke hente detaljer om deltakerlisten. Vennligst prøv igjen.
             </Heading>
           </Alert>
         </div>

--- a/apps/tiltakskoordinator-flate/src/api/api.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.test.ts
@@ -58,18 +58,6 @@ describe('getDeltakere', () => {
     expect(calledUrl).toContain('/deltakere-paged')
   })
 
-  it('sender gjennomforingId i body', async () => {
-    server.use(
-      http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
-        parsedBody = (await request.json()) as Record<string, unknown>
-        return HttpResponse.json(mockDeltakere)
-      })
-    )
-
-    await getDeltakere(DELTAKERLISTE_ID)
-    expect(parsedBody.gjennomforingId).toBeUndefined()
-  })
-
   it('sender statuser i body når de er oppgitt', async () => {
     server.use(
       http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
@@ -100,7 +88,7 @@ describe('getDeltakere', () => {
     expect(parsedBody.harForslagFraArrangor).toBe(true)
   })
 
-  it('gjennomforingId er ikke i body', async () => {
+  it('sender ikke gjennomforingId i body', async () => {
     server.use(
       http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
         parsedBody = (await request.json()) as Record<string, unknown>

--- a/apps/tiltakskoordinator-flate/src/api/api.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.test.ts
@@ -11,13 +11,15 @@ import {
   it
 } from 'vitest'
 import { v4 as uuidv4 } from 'uuid'
-import { getDeltakere, TilgangsFeil } from './api'
+import { getDeltakere, getDeltakerStatusCounts, TilgangsFeil } from './api'
 import { lagMockDeltaker } from '../mocks/mockData'
 
 const DELTAKERLISTE_ID = uuidv4()
 const API_BASE = '/amt-deltaker-bff'
 const ENDPOINT = (id: string) =>
   `${API_BASE}/tiltakskoordinator/deltakerliste/${id}/deltakere`
+const STATUS_COUNTS_ENDPOINT = (id: string) =>
+  `${API_BASE}/tiltakskoordinator/deltakerliste/${id}/deltakere/status-counts`
 
 const mockDeltakere = [
   {
@@ -156,5 +158,45 @@ describe('getDeltakere', () => {
     )
 
     await expect(getDeltakere(DELTAKERLISTE_ID)).rejects.toThrow()
+  })
+})
+
+describe('getDeltakerStatusCounts', () => {
+  it('returnerer status-tellinger fra backend', async () => {
+    const counts = {
+      VENTER_PA_OPPSTART: 1,
+      DELTAR: 6,
+      HAR_SLUTTET: 10
+    }
+
+    server.use(
+      http.post(STATUS_COUNTS_ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json(counts)
+      )
+    )
+
+    const result = await getDeltakerStatusCounts(DELTAKERLISTE_ID, {
+      statuser: [
+        DeltakerStatusType.VENTER_PA_OPPSTART,
+        DeltakerStatusType.DELTAR,
+        DeltakerStatusType.HAR_SLUTTET
+      ]
+    })
+
+    expect(result).toEqual(counts)
+  })
+
+  it('returnerer tilgangsfeil ved 403', async () => {
+    server.use(
+      http.post(STATUS_COUNTS_ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })
+      )
+    )
+
+    const result = await getDeltakerStatusCounts(DELTAKERLISTE_ID, {
+      statuser: [DeltakerStatusType.DELTAR]
+    })
+
+    expect(result).toBe(TilgangsFeil.IkkeTilgangTilDeltakerliste)
   })
 })

--- a/apps/tiltakskoordinator-flate/src/api/api.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.test.ts
@@ -17,7 +17,7 @@ import { lagMockDeltaker } from '../mocks/mockData'
 const DELTAKERLISTE_ID = uuidv4()
 const API_BASE = '/amt-deltaker-bff'
 const ENDPOINT = (id: string) =>
-  `${API_BASE}/tiltakskoordinator/deltakerliste/${id}/deltakere-paged`
+  `${API_BASE}/tiltakskoordinator/deltakerliste/${id}/deltakere`
 
 const mockDeltakere = [
   {
@@ -55,7 +55,7 @@ describe('getDeltakere', () => {
     )
 
     await getDeltakere(DELTAKERLISTE_ID)
-    expect(calledUrl).toContain('/deltakere-paged')
+    expect(calledUrl).toContain('/deltakere')
   })
 
   it('sender statuser i body når de er oppgitt', async () => {

--- a/apps/tiltakskoordinator-flate/src/api/api.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.test.ts
@@ -1,0 +1,148 @@
+import { DeltakerStatusType } from 'deltaker-flate-common'
+import { HttpResponse, http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { v4 as uuidv4 } from 'uuid'
+import { getDeltakere, TilgangsFeil } from './api'
+import { lagMockDeltaker } from '../mocks/mockData'
+
+const DELTAKERLISTE_ID = uuidv4()
+const API_BASE = '/amt-deltaker-bff'
+const ENDPOINT = (id: string) =>
+  `${API_BASE}/tiltakskoordinator/deltakerliste/${id}/deltakere-paged`
+
+const mockDeltakere = [
+  {
+    ...lagMockDeltaker(),
+    status: { type: DeltakerStatusType.DELTAR, aarsak: null },
+    harAktiveForslag: true
+  },
+  {
+    ...lagMockDeltaker(),
+    status: { type: DeltakerStatusType.SOKT_INN, aarsak: null },
+    harAktiveForslag: false
+  }
+]
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('getDeltakere', () => {
+  it('sender POST til riktig URL', async () => {
+    let calledUrl = ''
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), ({ request }) => {
+        calledUrl = request.url
+        return HttpResponse.json(mockDeltakere)
+      })
+    )
+
+    await getDeltakere(DELTAKERLISTE_ID)
+    expect(calledUrl).toContain('/deltakere-paged')
+  })
+
+  it('sender gjennomforingId i body', async () => {
+    let parsedBody: Record<string, unknown> = {}
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
+        parsedBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(mockDeltakere)
+      })
+    )
+
+    await getDeltakere(DELTAKERLISTE_ID)
+    expect(parsedBody.gjennomforingId).toBe(DELTAKERLISTE_ID)
+  })
+
+  it('sender statuser i body når de er oppgitt', async () => {
+    let parsedBody: Record<string, unknown> = {}
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
+        parsedBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(mockDeltakere)
+      })
+    )
+
+    await getDeltakere(DELTAKERLISTE_ID, {
+      gjennomforingId: DELTAKERLISTE_ID,
+      statuser: [DeltakerStatusType.DELTAR]
+    })
+
+    expect(parsedBody.statuser).toEqual([DeltakerStatusType.DELTAR])
+  })
+
+  it('sender harForslagFraArrangor i body når det er oppgitt', async () => {
+    let parsedBody: Record<string, unknown> = {}
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
+        parsedBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(mockDeltakere)
+      })
+    )
+
+    await getDeltakere(DELTAKERLISTE_ID, {
+      gjennomforingId: DELTAKERLISTE_ID,
+      harForslagFraArrangor: true
+    })
+
+    expect(parsedBody.harForslagFraArrangor).toBe(true)
+  })
+
+  it('returnerer deltakere ved 200-svar', async () => {
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json(mockDeltakere)
+      )
+    )
+
+    const result = await getDeltakere(DELTAKERLISTE_ID)
+    expect(Array.isArray(result)).toBe(true)
+    expect((result as unknown[]).length).toBe(mockDeltakere.length)
+  })
+
+  it('returnerer TilgangsFeil.ManglerADGruppe ved 401', async () => {
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      )
+    )
+
+    const result = await getDeltakere(DELTAKERLISTE_ID)
+    expect(result).toBe(TilgangsFeil.ManglerADGruppe)
+  })
+
+  it('returnerer TilgangsFeil.IkkeTilgangTilDeltakerliste ved 403', async () => {
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json({ error: 'Forbidden' }, { status: 403 })
+      )
+    )
+
+    const result = await getDeltakere(DELTAKERLISTE_ID)
+    expect(result).toBe(TilgangsFeil.IkkeTilgangTilDeltakerliste)
+  })
+
+  it('returnerer TilgangsFeil.DeltakerlisteStengt ved 410', async () => {
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json({ error: 'Gone' }, { status: 410 })
+      )
+    )
+
+    const result = await getDeltakere(DELTAKERLISTE_ID)
+    expect(result).toBe(TilgangsFeil.DeltakerlisteStengt)
+  })
+
+  it('kaster feil ved 500', async () => {
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), () =>
+        HttpResponse.json({ error: 'Server Error' }, { status: 500 })
+      )
+    )
+
+    await expect(getDeltakere(DELTAKERLISTE_ID)).rejects.toThrow()
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/api/api.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.test.ts
@@ -1,7 +1,15 @@
 import { DeltakerStatusType } from 'deltaker-flate-common'
 import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it
+} from 'vitest'
 import { v4 as uuidv4 } from 'uuid'
 import { getDeltakere, TilgangsFeil } from './api'
 import { lagMockDeltaker } from '../mocks/mockData'
@@ -31,6 +39,12 @@ afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 describe('getDeltakere', () => {
+  let parsedBody: Record<string, unknown> = {}
+
+  beforeEach(() => {
+    parsedBody = {}
+  })
+
   it('sender POST til riktig URL', async () => {
     let calledUrl = ''
     server.use(
@@ -45,7 +59,6 @@ describe('getDeltakere', () => {
   })
 
   it('sender gjennomforingId i body', async () => {
-    let parsedBody: Record<string, unknown> = {}
     server.use(
       http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
         parsedBody = (await request.json()) as Record<string, unknown>
@@ -54,11 +67,10 @@ describe('getDeltakere', () => {
     )
 
     await getDeltakere(DELTAKERLISTE_ID)
-    expect(parsedBody.gjennomforingId).toBe(DELTAKERLISTE_ID)
+    expect(parsedBody.gjennomforingId).toBeUndefined()
   })
 
   it('sender statuser i body når de er oppgitt', async () => {
-    let parsedBody: Record<string, unknown> = {}
     server.use(
       http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
         parsedBody = (await request.json()) as Record<string, unknown>
@@ -67,7 +79,6 @@ describe('getDeltakere', () => {
     )
 
     await getDeltakere(DELTAKERLISTE_ID, {
-      gjennomforingId: DELTAKERLISTE_ID,
       statuser: [DeltakerStatusType.DELTAR]
     })
 
@@ -75,7 +86,6 @@ describe('getDeltakere', () => {
   })
 
   it('sender harForslagFraArrangor i body når det er oppgitt', async () => {
-    let parsedBody: Record<string, unknown> = {}
     server.use(
       http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
         parsedBody = (await request.json()) as Record<string, unknown>
@@ -84,11 +94,25 @@ describe('getDeltakere', () => {
     )
 
     await getDeltakere(DELTAKERLISTE_ID, {
-      gjennomforingId: DELTAKERLISTE_ID,
       harForslagFraArrangor: true
     })
 
     expect(parsedBody.harForslagFraArrangor).toBe(true)
+  })
+
+  it('gjennomforingId er ikke i body', async () => {
+    server.use(
+      http.post(ENDPOINT(DELTAKERLISTE_ID), async ({ request }) => {
+        parsedBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(mockDeltakere)
+      })
+    )
+
+    await getDeltakere(DELTAKERLISTE_ID, {
+      statuser: [DeltakerStatusType.DELTAR]
+    })
+
+    expect(parsedBody.gjennomforingId).toBeUndefined()
   })
 
   it('returnerer deltakere ved 200-svar', async () => {

--- a/apps/tiltakskoordinator-flate/src/api/api.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.test.ts
@@ -164,9 +164,16 @@ describe('getDeltakere', () => {
 describe('getDeltakerStatusCounts', () => {
   it('returnerer status-tellinger fra backend', async () => {
     const counts = {
-      VENTER_PA_OPPSTART: 1,
-      DELTAR: 6,
-      HAR_SLUTTET: 10
+      statusCounts: {
+        VENTER_PA_OPPSTART: 1,
+        DELTAR: 6,
+        HAR_SLUTTET: 10
+      },
+      handlingCounts: {
+        AktiveForslag: 3,
+        OppdateringFraNav: 2,
+        NyeDeltakere: 1
+      }
     }
 
     server.use(

--- a/apps/tiltakskoordinator-flate/src/api/api.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.ts
@@ -9,9 +9,9 @@ import { DeltakerDetaljer, deltakerDetaljerSchema } from './data/deltaker.ts'
 import {
   Deltaker,
   Deltakere,
+  DeltakerFilterCounts,
+  deltakerFilterCountsSchema,
   deltakereSchema,
-  DeltakerStatusCounts,
-  deltakerStatusCountsSchema,
   DeltakerlisteDetaljer,
   deltakerlisteDetaljerSchema,
   deltakerSchema,
@@ -71,7 +71,7 @@ export enum TilgangsFeil {
 }
 
 export type DeltakereResponse = Deltakere | TilgangsFeil
-export type DeltakerStatusCountsResponse = DeltakerStatusCounts | TilgangsFeil
+export type DeltakerFilterCountsResponse = DeltakerFilterCounts | TilgangsFeil
 
 export const getDeltakere = async (
   deltakerlisteId: string,
@@ -114,7 +114,7 @@ export const getDeltakere = async (
 export const getDeltakerStatusCounts = async (
   deltakerlisteId: string,
   request: TiltaksKoordinatorDeltakerlisteRequest
-): Promise<DeltakerStatusCountsResponse> => {
+): Promise<DeltakerFilterCountsResponse> => {
   return fetch(`${apiUrl(deltakerlisteId)}/deltakere/status-counts`, {
     method: 'POST',
     credentials: 'include',
@@ -134,13 +134,13 @@ export const getDeltakerStatusCounts = async (
     }
 
     try {
-      return deltakerStatusCountsSchema.parse(await response.json())
+      return deltakerFilterCountsSchema.parse(await response.json())
     } catch (error) {
       if (error instanceof ZodError) {
         logError('ZodError', error.issues)
       } else {
         logError(
-          'Kunne ikke parse deltakerStatusCountsSchema for getDeltakerStatusCounts',
+          'Kunne ikke parse deltakerFilterCountsSchema for getDeltakerStatusCounts',
           deltakerlisteId
         )
       }

--- a/apps/tiltakskoordinator-flate/src/api/api.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.ts
@@ -12,7 +12,8 @@ import {
   deltakereSchema,
   DeltakerlisteDetaljer,
   deltakerlisteDetaljerSchema,
-  deltakerSchema
+  deltakerSchema,
+  TiltaksKoordinatorDeltakerlisteRequest
 } from './data/deltakerliste'
 import { ZodError } from 'zod'
 
@@ -70,11 +71,16 @@ export enum TilgangsFeil {
 export type DeltakereResponse = Deltakere | TilgangsFeil
 
 export const getDeltakere = async (
-  deltakerlisteId: string
+  deltakerlisteId: string,
+  request?: TiltaksKoordinatorDeltakerlisteRequest
 ): Promise<DeltakereResponse> => {
-  return fetch(`${apiUrl(deltakerlisteId)}/deltakere`, {
-    method: 'GET',
+  return fetch(`${apiUrl(deltakerlisteId)}/deltakere-paged`, {
+    method: 'POST',
     credentials: 'include',
+    body: JSON.stringify({
+      gjennomforingId: deltakerlisteId,
+      ...request
+    }),
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',

--- a/apps/tiltakskoordinator-flate/src/api/api.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.ts
@@ -74,7 +74,7 @@ export const getDeltakere = async (
   deltakerlisteId: string,
   filter?: TiltaksKoordinatorDeltakerlisteRequest
 ): Promise<DeltakereResponse> => {
-  return fetch(`${apiUrl(deltakerlisteId)}/deltakere-paged`, {
+  return fetch(`${apiUrl(deltakerlisteId)}/deltakere`, {
     method: 'POST',
     credentials: 'include',
     body: JSON.stringify(filter ?? {}),

--- a/apps/tiltakskoordinator-flate/src/api/api.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.ts
@@ -10,6 +10,8 @@ import {
   Deltaker,
   Deltakere,
   deltakereSchema,
+  DeltakerStatusCounts,
+  deltakerStatusCountsSchema,
   DeltakerlisteDetaljer,
   deltakerlisteDetaljerSchema,
   deltakerSchema,
@@ -69,6 +71,7 @@ export enum TilgangsFeil {
 }
 
 export type DeltakereResponse = Deltakere | TilgangsFeil
+export type DeltakerStatusCountsResponse = DeltakerStatusCounts | TilgangsFeil
 
 export const getDeltakere = async (
   deltakerlisteId: string,
@@ -104,6 +107,47 @@ export const getDeltakere = async (
       }
 
       throw new Error('Kunne ikke laste inn deltakere. Prøv igjen senere')
+    }
+  })
+}
+
+export const getDeltakerStatusCounts = async (
+  deltakerlisteId: string,
+  request: TiltaksKoordinatorDeltakerlisteRequest
+): Promise<DeltakerStatusCountsResponse> => {
+  return fetch(`${apiUrl(deltakerlisteId)}/deltakere/status-counts`, {
+    method: 'POST',
+    credentials: 'include',
+    body: JSON.stringify(request),
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'Nav-Consumer-Id': APP_NAME
+    }
+  }).then(async (response) => {
+    if (harTilgansfeil(response)) {
+      return handleTilgangsfeil(response)
+    }
+    if (response.status !== 200) {
+      const message = 'Status-tellinger kunne ikke hentes.'
+      handleError(message, deltakerlisteId, response.status, null)
+    }
+
+    try {
+      return deltakerStatusCountsSchema.parse(await response.json())
+    } catch (error) {
+      if (error instanceof ZodError) {
+        logError('ZodError', error.issues)
+      } else {
+        logError(
+          'Kunne ikke parse deltakerStatusCountsSchema for getDeltakerStatusCounts',
+          deltakerlisteId
+        )
+      }
+
+      throw new Error(
+        'Kunne ikke laste inn status-tellinger. Prøv igjen senere.'
+      )
     }
   })
 }

--- a/apps/tiltakskoordinator-flate/src/api/api.ts
+++ b/apps/tiltakskoordinator-flate/src/api/api.ts
@@ -72,15 +72,12 @@ export type DeltakereResponse = Deltakere | TilgangsFeil
 
 export const getDeltakere = async (
   deltakerlisteId: string,
-  request?: TiltaksKoordinatorDeltakerlisteRequest
+  filter?: TiltaksKoordinatorDeltakerlisteRequest
 ): Promise<DeltakereResponse> => {
   return fetch(`${apiUrl(deltakerlisteId)}/deltakere-paged`, {
     method: 'POST',
     credentials: 'include',
-    body: JSON.stringify({
-      gjennomforingId: deltakerlisteId,
-      ...request
-    }),
+    body: JSON.stringify(filter ?? {}),
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.test.ts
@@ -1,0 +1,63 @@
+import { DeltakerStatusType } from 'deltaker-flate-common'
+import { describe, expect, it } from 'vitest'
+import { v4 as uuidv4 } from 'uuid'
+import { tiltaksKoordinatorDeltakerlisteRequestSchema } from './deltakerliste'
+
+const gyldigId = uuidv4()
+
+describe('tiltaksKoordinatorDeltakerlisteRequestSchema', () => {
+  it('godtar gyldig request med bare gjennomforingId', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      gjennomforingId: gyldigId
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('godtar request med alle felter', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      gjennomforingId: gyldigId,
+      harForslagFraArrangor: true,
+      statuser: [DeltakerStatusType.DELTAR, DeltakerStatusType.SOKT_INN]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('godtar request uten valgfrie felter', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      gjennomforingId: gyldigId,
+      harForslagFraArrangor: false,
+      statuser: []
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('avviser request uten gjennomforingId', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      harForslagFraArrangor: true
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('avviser request med ugyldig UUID som gjennomforingId', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      gjennomforingId: 'ikke-en-uuid'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('avviser request med ugyldig status', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      gjennomforingId: gyldigId,
+      statuser: ['UGYLDIG_STATUS']
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('avviser request med ugyldig type for harForslagFraArrangor', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
+      gjennomforingId: gyldigId,
+      harForslagFraArrangor: 'ja'
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.test.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.test.ts
@@ -1,53 +1,31 @@
 import { DeltakerStatusType } from 'deltaker-flate-common'
 import { describe, expect, it } from 'vitest'
-import { v4 as uuidv4 } from 'uuid'
 import { tiltaksKoordinatorDeltakerlisteRequestSchema } from './deltakerliste'
 
-const gyldigId = uuidv4()
-
 describe('tiltaksKoordinatorDeltakerlisteRequestSchema', () => {
-  it('godtar gyldig request med bare gjennomforingId', () => {
-    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      gjennomforingId: gyldigId
-    })
+  it('godtar tomt objekt (alle felter er valgfrie)', () => {
+    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({})
     expect(result.success).toBe(true)
   })
 
   it('godtar request med alle felter', () => {
     const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      gjennomforingId: gyldigId,
       harForslagFraArrangor: true,
       statuser: [DeltakerStatusType.DELTAR, DeltakerStatusType.SOKT_INN]
     })
     expect(result.success).toBe(true)
   })
 
-  it('godtar request uten valgfrie felter', () => {
+  it('godtar request med tomme statuser', () => {
     const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      gjennomforingId: gyldigId,
       harForslagFraArrangor: false,
       statuser: []
     })
     expect(result.success).toBe(true)
   })
 
-  it('avviser request uten gjennomforingId', () => {
-    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      harForslagFraArrangor: true
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('avviser request med ugyldig UUID som gjennomforingId', () => {
-    const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      gjennomforingId: 'ikke-en-uuid'
-    })
-    expect(result.success).toBe(false)
-  })
-
   it('avviser request med ugyldig status', () => {
     const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      gjennomforingId: gyldigId,
       statuser: ['UGYLDIG_STATUS']
     })
     expect(result.success).toBe(false)
@@ -55,7 +33,6 @@ describe('tiltaksKoordinatorDeltakerlisteRequestSchema', () => {
 
   it('avviser request med ugyldig type for harForslagFraArrangor', () => {
     const result = tiltaksKoordinatorDeltakerlisteRequestSchema.safeParse({
-      gjennomforingId: gyldigId,
       harForslagFraArrangor: 'ja'
     })
     expect(result.success).toBe(false)

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -80,6 +80,11 @@ export const tiltaksKoordinatorDeltakerlisteRequestSchema = z.object({
   statuser: z.array(z.enum(DeltakerStatusType)).optional()
 })
 
+export const deltakerStatusCountsSchema = z.partialRecord(
+  z.enum(DeltakerStatusType),
+  z.number().int().nonnegative()
+)
+
 export type Deltaker = z.infer<typeof deltakerSchema>
 export type Deltakere = z.infer<typeof deltakereSchema>
 export type DeltakerlisteDetaljer = z.infer<typeof deltakerlisteDetaljerSchema>
@@ -87,3 +92,4 @@ export type Koordinator = z.infer<typeof koordinatorSchema>
 export type TiltaksKoordinatorDeltakerlisteRequest = z.infer<
   typeof tiltaksKoordinatorDeltakerlisteRequestSchema
 >
+export type DeltakerStatusCounts = z.infer<typeof deltakerStatusCountsSchema>

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -85,6 +85,22 @@ export const deltakerStatusCountsSchema = z.partialRecord(
   z.number().int().nonnegative()
 )
 
+export const handlingFilterValgSchema = z.enum([
+  'AktiveForslag',
+  'OppdateringFraNav',
+  'NyeDeltakere'
+])
+
+export const deltakerHandlingCountsSchema = z.partialRecord(
+  handlingFilterValgSchema,
+  z.number().int().nonnegative()
+)
+
+export const deltakerFilterCountsSchema = z.object({
+  statusCounts: deltakerStatusCountsSchema,
+  handlingCounts: deltakerHandlingCountsSchema
+})
+
 export type Deltaker = z.infer<typeof deltakerSchema>
 export type Deltakere = z.infer<typeof deltakereSchema>
 export type DeltakerlisteDetaljer = z.infer<typeof deltakerlisteDetaljerSchema>
@@ -93,3 +109,7 @@ export type TiltaksKoordinatorDeltakerlisteRequest = z.infer<
   typeof tiltaksKoordinatorDeltakerlisteRequestSchema
 >
 export type DeltakerStatusCounts = z.infer<typeof deltakerStatusCountsSchema>
+export type DeltakerHandlingCounts = z.infer<
+  typeof deltakerHandlingCountsSchema
+>
+export type DeltakerFilterCounts = z.infer<typeof deltakerFilterCountsSchema>

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -76,7 +76,6 @@ export const deltakerlisteDetaljerSchema = z.object({
 })
 
 export const tiltaksKoordinatorDeltakerlisteRequestSchema = z.object({
-  gjennomforingId: z.uuid(),
   harForslagFraArrangor: z.boolean().optional(),
   statuser: z.array(z.enum(DeltakerStatusType)).optional()
 })

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -75,7 +75,16 @@ export const deltakerlisteDetaljerSchema = z.object({
   erEnkeltplass: z.boolean()
 })
 
+export const tiltaksKoordinatorDeltakerlisteRequestSchema = z.object({
+  gjennomforingId: z.uuid(),
+  harForslagFraArrangor: z.boolean().optional(),
+  statuser: z.array(z.enum(DeltakerStatusType)).optional()
+})
+
 export type Deltaker = z.infer<typeof deltakerSchema>
 export type Deltakere = z.infer<typeof deltakereSchema>
 export type DeltakerlisteDetaljer = z.infer<typeof deltakerlisteDetaljerSchema>
 export type Koordinator = z.infer<typeof koordinatorSchema>
+export type TiltaksKoordinatorDeltakerlisteRequest = z.infer<
+  typeof tiltaksKoordinatorDeltakerlisteRequestSchema
+>

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterCounts.test.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterCounts.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DeltakerStatusType, Pameldingstype } from 'deltaker-flate-common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DeltakerHandlingCounts,
+  DeltakerStatusCounts
+} from '../../api/data/deltakerliste'
+import { DeltakerlisteContextProvider } from '../../context-providers/DeltakerlisteContext'
+import { FilterContextProvider } from '../../context-providers/FilterContext'
+import {
+  createMockDeltakerlisteDetaljer,
+  lagMockDeltaker
+} from '../../mocks/mockData'
+import { HendelseFilter } from './HendelseFilter'
+import { StatusFilter } from './StatusFilter'
+
+const HENDELSE_FILTER_OPEN_KEY = 'deltaker-liste-filter-hendelser-open'
+const STATUS_FILTER_OPEN_KEY = 'deltaker-liste-filter-status-open'
+
+const renderFilterPanel = (
+  statusCounts: DeltakerStatusCounts,
+  handlingCounts: DeltakerHandlingCounts
+) => {
+  const detaljer = {
+    ...createMockDeltakerlisteDetaljer(),
+    pameldingstype: Pameldingstype.TRENGER_GODKJENNING
+  }
+
+  const deltakere = [
+    {
+      ...lagMockDeltaker(),
+      status: { type: DeltakerStatusType.DELTAR, aarsak: null },
+      harAktiveForslag: false,
+      harOppdateringFraNav: false,
+      erNyDeltaker: false
+    },
+    {
+      ...lagMockDeltaker(),
+      status: { type: DeltakerStatusType.HAR_SLUTTET, aarsak: null },
+      harAktiveForslag: true,
+      harOppdateringFraNav: true,
+      erNyDeltaker: true
+    }
+  ]
+
+  return render(
+    <FilterContextProvider>
+      <DeltakerlisteContextProvider
+        initialDeltakerlisteDetaljer={detaljer}
+        initialDeltakere={deltakere}
+        initialStatusCounts={statusCounts}
+        initialHandlingCounts={handlingCounts}
+      >
+        <HendelseFilter />
+        <StatusFilter />
+      </DeltakerlisteContextProvider>
+    </FilterContextProvider>
+  )
+}
+
+describe('Filter counts from backend', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+      clear: () => {
+        storage.clear()
+      }
+    })
+
+    localStorage.setItem(HENDELSE_FILTER_OPEN_KEY, 'true')
+    localStorage.setItem(STATUS_FILTER_OPEN_KEY, 'true')
+  })
+
+  it('beholder hendelse-counts når statusfilter endres', async () => {
+    const user = userEvent.setup()
+
+    renderFilterPanel(
+      { DELTAR: 44, HAR_SLUTTET: 55 },
+      { AktiveForslag: 12, OppdateringFraNav: 13, NyeDeltakere: 14 }
+    )
+
+    const aktiveForslagRow = screen
+      .getByText('Forslag fra arrangør')
+      .closest('label')
+    expect(aktiveForslagRow?.textContent ?? '').toContain('12')
+
+    const deltarRow = screen.getByText('Deltar').closest('label')
+    expect(deltarRow).not.toBeNull()
+
+    // Toggler et statusfilter som tidligere kunne påvirke lokalberegnet antall.
+    await user.click(deltarRow!)
+
+    expect(aktiveForslagRow?.textContent ?? '').toContain('12')
+  })
+
+  it('beholder status-counts når hendelsesfilter endres', async () => {
+    const user = userEvent.setup()
+
+    renderFilterPanel(
+      { DELTAR: 44, HAR_SLUTTET: 55 },
+      { AktiveForslag: 12, OppdateringFraNav: 13, NyeDeltakere: 14 }
+    )
+
+    const deltarRow = screen.getByText('Deltar').closest('label')
+    expect(deltarRow?.textContent ?? '').toContain('44')
+
+    const aktiveForslagRow = screen
+      .getByText('Forslag fra arrangør')
+      .closest('label')
+    expect(aktiveForslagRow).not.toBeNull()
+
+    // Toggler et hendelsesfilter som tidligere kunne påvirke lokalberegnet antall.
+    await user.click(aktiveForslagRow!)
+
+    expect(deltarRow?.textContent ?? '').toContain('44')
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterCounts.test.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterCounts.test.tsx
@@ -51,6 +51,7 @@ const renderFilterPanel = (
         initialDeltakere={deltakere}
         initialStatusCounts={statusCounts}
         initialHandlingCounts={handlingCounts}
+        initialFilterCountsLaster={false}
       >
         <HendelseFilter />
         <StatusFilter />

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterCounts.test.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterCounts.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DeltakerStatusType, Pameldingstype } from 'deltaker-flate-common'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DeltakerHandlingCounts,
   DeltakerStatusCounts
@@ -60,6 +60,10 @@ const renderFilterPanel = (
 }
 
 describe('Filter counts from backend', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   beforeEach(() => {
     const storage = new Map<string, string>()
     vi.stubGlobal('localStorage', {

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
@@ -15,7 +15,8 @@ import {
 } from '../../utils/filter-deltakerliste'
 
 export const HendelseFilter = () => {
-  const { deltakerlisteDetaljer, handlingCounts } = useDeltakerlisteContext()
+  const { deltakerlisteDetaljer, handlingCounts, filterCountsLaster } =
+    useDeltakerlisteContext()
   const { valgteHendelseFilter, setValgteHendelseFilter } = useFilterContext()
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
     'deltaker-liste-filter-hendelser-open',
@@ -72,7 +73,9 @@ export const HendelseFilter = () => {
               <span className="flex justify-between w-full gap-2">
                 <span className="whitespace-nowrap">{filter.navn}</span>
                 <BodyShort as="span" weight="semibold">
-                  {handlingCounts[filter.filtervalg] ?? 0}
+                  {filterCountsLaster
+                    ? '-'
+                    : (handlingCounts[filter.filtervalg] ?? 0)}
                 </BodyShort>
               </span>
             </Checkbox>

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
@@ -14,7 +14,8 @@ import {
 } from '../../utils/filter-deltakerliste'
 
 export const HendelseFilter = () => {
-  const { deltakere, deltakerlisteDetaljer } = useDeltakerlisteContext()
+  const { deltakere, deltakerlisteDetaljer, handlingCounts } =
+    useDeltakerlisteContext()
   const { valgteHendelseFilter, valgteStatusFilter, setValgteHendelseFilter } =
     useFilterContext()
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
@@ -73,7 +74,7 @@ export const HendelseFilter = () => {
               <span className="flex justify-between w-full gap-2">
                 <span className="whitespace-nowrap">{filter.navn}</span>
                 <BodyShort as="span" weight="semibold">
-                  {filter.antall}
+                  {handlingCounts[filter.filtervalg] ?? 0}
                 </BodyShort>
               </span>
             </Checkbox>

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
@@ -4,38 +4,36 @@ import {
   CheckboxGroup,
   ExpansionCard
 } from '@navikt/ds-react'
+import { kreverGodkjenningForPamelding } from 'deltaker-flate-common'
 import { useMemo } from 'react'
 import useLocalStorage from '../../../../../packages/deltaker-flate-common/hooks/useLocalStorage'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../../context-providers/FilterContext'
 import {
   HandlingFilterValg,
-  getHendelseFilterDetaljer
+  getHandlingFilterTypeNavn
 } from '../../utils/filter-deltakerliste'
 
 export const HendelseFilter = () => {
-  const { deltakere, deltakerlisteDetaljer, handlingCounts } =
-    useDeltakerlisteContext()
-  const { valgteHendelseFilter, valgteStatusFilter, setValgteHendelseFilter } =
-    useFilterContext()
+  const { deltakerlisteDetaljer, handlingCounts } = useDeltakerlisteContext()
+  const { valgteHendelseFilter, setValgteHendelseFilter } = useFilterContext()
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
     'deltaker-liste-filter-hendelser-open',
     false
   )
 
   const filterDetaljer = useMemo(() => {
-    return getHendelseFilterDetaljer(
-      deltakere,
-      valgteHendelseFilter,
-      valgteStatusFilter,
-      deltakerlisteDetaljer.pameldingstype
-    )
-  }, [
-    valgteHendelseFilter,
-    valgteStatusFilter,
-    deltakere,
-    deltakerlisteDetaljer
-  ])
+    return Object.values(HandlingFilterValg)
+      .filter((filterValg) =>
+        kreverGodkjenningForPamelding(deltakerlisteDetaljer.pameldingstype)
+          ? true
+          : filterValg === HandlingFilterValg.AktiveForslag
+      )
+      .map((filterValg) => ({
+        filtervalg: filterValg,
+        navn: getHandlingFilterTypeNavn(filterValg)
+      }))
+  }, [deltakerlisteDetaljer.pameldingstype])
 
   const handleChange = (nyValgteFilter: string[]) => {
     setValgteHendelseFilter(

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -21,11 +21,15 @@ export const StatusFilter = () => {
   )
 
   const filtre = useMemo(() => {
-    return getFilterStatuser(
-      deltakerlisteDetaljer.oppstartstype,
-      deltakerlisteDetaljer.pameldingstype,
-      deltakerlisteDetaljer.tiltakskode
-    )
+    return [
+      ...new Set(
+        getFilterStatuser(
+          deltakerlisteDetaljer.oppstartstype,
+          deltakerlisteDetaljer.pameldingstype,
+          deltakerlisteDetaljer.tiltakskode
+        )
+      )
+    ]
   }, [
     deltakerlisteDetaljer.oppstartstype,
     deltakerlisteDetaljer.pameldingstype,

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -15,7 +15,8 @@ import {
 } from '../../utils/filter-deltakerliste'
 
 export const StatusFilter = () => {
-  const { deltakere, deltakerlisteDetaljer } = useDeltakerlisteContext()
+  const { deltakere, deltakerlisteDetaljer, statusCounts } =
+    useDeltakerlisteContext()
   const { valgteStatusFilter, valgteHendelseFilter, setValgteStatusFilter } =
     useFilterContext()
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
@@ -77,7 +78,7 @@ export const StatusFilter = () => {
                 <span className="flex justify-between w-full gap-2">
                   <span className="whitespace-nowrap">{filter.navn}</span>
                   <BodyShort as="span" weight="semibold">
-                    {filter.antall}
+                    {statusCounts[filter.filtervalg] ?? filter.antall}
                   </BodyShort>
                 </span>
               </Checkbox>

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -78,7 +78,7 @@ export const StatusFilter = () => {
                 <span className="flex justify-between w-full gap-2">
                   <span className="whitespace-nowrap">{filter.navn}</span>
                   <BodyShort as="span" weight="semibold">
-                    {statusCounts[filter.filtervalg] ?? filter.antall}
+                    {statusCounts[filter.filtervalg] ?? 0}
                   </BodyShort>
                 </span>
               </Checkbox>

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -4,33 +4,21 @@ import {
   CheckboxGroup,
   ExpansionCard
 } from '@navikt/ds-react'
+import { getDeltakerStatusDisplayText } from 'deltaker-flate-common'
 import { useMemo } from 'react'
 import useLocalStorage from '../../../../../packages/deltaker-flate-common/hooks/useLocalStorage'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../../context-providers/FilterContext'
 import type { StatusFilterValg } from '../../utils/filter-deltakerliste'
-import {
-  getFilterStatuser,
-  getStatusFilterDetaljer
-} from '../../utils/filter-deltakerliste'
+import { getFilterStatuser } from '../../utils/filter-deltakerliste'
 
 export const StatusFilter = () => {
-  const { deltakere, deltakerlisteDetaljer, statusCounts } =
-    useDeltakerlisteContext()
-  const { valgteStatusFilter, valgteHendelseFilter, setValgteStatusFilter } =
-    useFilterContext()
+  const { deltakerlisteDetaljer, statusCounts } = useDeltakerlisteContext()
+  const { valgteStatusFilter, setValgteStatusFilter } = useFilterContext()
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
     'deltaker-liste-filter-status-open',
     false
   )
-
-  const filterDetaljer = useMemo(() => {
-    return getStatusFilterDetaljer(
-      deltakere,
-      valgteStatusFilter,
-      valgteHendelseFilter
-    )
-  }, [valgteStatusFilter, valgteHendelseFilter, deltakere])
 
   const filtre = useMemo(() => {
     return getFilterStatuser(
@@ -43,6 +31,15 @@ export const StatusFilter = () => {
     deltakerlisteDetaljer.pameldingstype,
     deltakerlisteDetaljer.tiltakskode
   ])
+
+  const filterDetaljer = useMemo(
+    () =>
+      filtre.map((filtervalg) => ({
+        filtervalg,
+        navn: getDeltakerStatusDisplayText(filtervalg)
+      })),
+    [filtre]
+  )
 
   const handleChange = (nyValgteFilter: string[]) => {
     setValgteStatusFilter(nyValgteFilter as StatusFilterValg[])
@@ -69,20 +66,16 @@ export const StatusFilter = () => {
           onChange={handleChange}
           value={valgteStatusFilter}
         >
-          {filterDetaljer
-            .filter((filter) => {
-              return filtre.includes(filter.filtervalg)
-            })
-            .map((filter) => (
-              <Checkbox key={filter.filtervalg} value={filter.filtervalg}>
-                <span className="flex justify-between w-full gap-2">
-                  <span className="whitespace-nowrap">{filter.navn}</span>
-                  <BodyShort as="span" weight="semibold">
-                    {statusCounts[filter.filtervalg] ?? 0}
-                  </BodyShort>
-                </span>
-              </Checkbox>
-            ))}
+          {filterDetaljer.map((filter) => (
+            <Checkbox key={filter.filtervalg} value={filter.filtervalg}>
+              <span className="flex justify-between w-full gap-2">
+                <span className="whitespace-nowrap">{filter.navn}</span>
+                <BodyShort as="span" weight="semibold">
+                  {statusCounts[filter.filtervalg] ?? 0}
+                </BodyShort>
+              </span>
+            </Checkbox>
+          ))}
         </CheckboxGroup>
       </ExpansionCard.Content>
     </ExpansionCard>

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -13,7 +13,8 @@ import type { StatusFilterValg } from '../../utils/filter-deltakerliste'
 import { getFilterStatuser } from '../../utils/filter-deltakerliste'
 
 export const StatusFilter = () => {
-  const { deltakerlisteDetaljer, statusCounts } = useDeltakerlisteContext()
+  const { deltakerlisteDetaljer, statusCounts, filterCountsLaster } =
+    useDeltakerlisteContext()
   const { valgteStatusFilter, setValgteStatusFilter } = useFilterContext()
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
     'deltaker-liste-filter-status-open',
@@ -75,7 +76,9 @@ export const StatusFilter = () => {
               <span className="flex justify-between w-full gap-2">
                 <span className="whitespace-nowrap">{filter.navn}</span>
                 <BodyShort as="span" weight="semibold">
-                  {statusCounts[filter.filtervalg] ?? 0}
+                  {filterCountsLaster
+                    ? '-'
+                    : (statusCounts[filter.filtervalg] ?? 0)}
                 </BodyShort>
               </span>
             </Checkbox>

--- a/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
@@ -1,9 +1,14 @@
 import { createContext, useContext, useState } from 'react'
-import { Deltakere, DeltakerlisteDetaljer } from '../api/data/deltakerliste'
+import {
+  Deltakere,
+  DeltakerlisteDetaljer,
+  DeltakerStatusCounts
+} from '../api/data/deltakerliste'
 
 export interface DeltakerListeContextProps {
   deltakerlisteDetaljer: DeltakerlisteDetaljer
   deltakere: Deltakere
+  statusCounts: DeltakerStatusCounts
   filtrerteDeltakere: Deltakere
   setDeltakerlisteDetaljer: React.Dispatch<
     React.SetStateAction<DeltakerlisteDetaljer>
@@ -31,21 +36,25 @@ const useDeltakerlisteContext = () => {
 const DeltakerlisteContextProvider = ({
   initialDeltakerlisteDetaljer,
   initialDeltakere,
+  initialStatusCounts,
   children
 }: {
   initialDeltakerlisteDetaljer: DeltakerlisteDetaljer
   initialDeltakere: Deltakere
+  initialStatusCounts: DeltakerStatusCounts
   children: React.ReactNode
 }) => {
   const [deltakerlisteDetaljer, setDeltakerlisteDetaljer] = useState(
     initialDeltakerlisteDetaljer
   )
   const [deltakere, setDelakere] = useState(initialDeltakere)
+  const [statusCounts] = useState(initialStatusCounts)
   const [filtrerteDeltakere, setFiltrerteDeltakere] = useState(initialDeltakere)
 
   const contextValue: DeltakerListeContextProps = {
     deltakerlisteDetaljer: deltakerlisteDetaljer,
     deltakere: deltakere,
+    statusCounts: statusCounts,
     filtrerteDeltakere: filtrerteDeltakere,
     setDeltakerlisteDetaljer: setDeltakerlisteDetaljer,
     setDeltakere: setDelakere,

--- a/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
@@ -52,15 +52,13 @@ const DeltakerlisteContextProvider = ({
     initialDeltakerlisteDetaljer
   )
   const [deltakere, setDelakere] = useState(initialDeltakere)
-  const [statusCounts] = useState(initialStatusCounts)
-  const [handlingCounts] = useState(initialHandlingCounts)
   const [filtrerteDeltakere, setFiltrerteDeltakere] = useState(initialDeltakere)
 
   const contextValue: DeltakerListeContextProps = {
     deltakerlisteDetaljer: deltakerlisteDetaljer,
     deltakere: deltakere,
-    statusCounts: statusCounts,
-    handlingCounts: handlingCounts,
+    statusCounts: initialStatusCounts,
+    handlingCounts: initialHandlingCounts,
     filtrerteDeltakere: filtrerteDeltakere,
     setDeltakerlisteDetaljer: setDeltakerlisteDetaljer,
     setDeltakere: setDelakere,

--- a/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
@@ -11,6 +11,7 @@ export interface DeltakerListeContextProps {
   deltakere: Deltakere
   statusCounts: DeltakerStatusCounts
   handlingCounts: DeltakerHandlingCounts
+  filterCountsLaster: boolean
   filtrerteDeltakere: Deltakere
   setDeltakerlisteDetaljer: React.Dispatch<
     React.SetStateAction<DeltakerlisteDetaljer>
@@ -40,12 +41,14 @@ const DeltakerlisteContextProvider = ({
   initialDeltakere,
   initialStatusCounts,
   initialHandlingCounts,
+  initialFilterCountsLaster,
   children
 }: {
   initialDeltakerlisteDetaljer: DeltakerlisteDetaljer
   initialDeltakere: Deltakere
   initialStatusCounts: DeltakerStatusCounts
   initialHandlingCounts: DeltakerHandlingCounts
+  initialFilterCountsLaster: boolean
   children: React.ReactNode
 }) => {
   const [deltakerlisteDetaljer, setDeltakerlisteDetaljer] = useState(
@@ -59,6 +62,7 @@ const DeltakerlisteContextProvider = ({
     deltakere: deltakere,
     statusCounts: initialStatusCounts,
     handlingCounts: initialHandlingCounts,
+    filterCountsLaster: initialFilterCountsLaster,
     filtrerteDeltakere: filtrerteDeltakere,
     setDeltakerlisteDetaljer: setDeltakerlisteDetaljer,
     setDeltakere: setDelakere,

--- a/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/DeltakerlisteContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState } from 'react'
 import {
   Deltakere,
+  DeltakerHandlingCounts,
   DeltakerlisteDetaljer,
   DeltakerStatusCounts
 } from '../api/data/deltakerliste'
@@ -9,6 +10,7 @@ export interface DeltakerListeContextProps {
   deltakerlisteDetaljer: DeltakerlisteDetaljer
   deltakere: Deltakere
   statusCounts: DeltakerStatusCounts
+  handlingCounts: DeltakerHandlingCounts
   filtrerteDeltakere: Deltakere
   setDeltakerlisteDetaljer: React.Dispatch<
     React.SetStateAction<DeltakerlisteDetaljer>
@@ -37,11 +39,13 @@ const DeltakerlisteContextProvider = ({
   initialDeltakerlisteDetaljer,
   initialDeltakere,
   initialStatusCounts,
+  initialHandlingCounts,
   children
 }: {
   initialDeltakerlisteDetaljer: DeltakerlisteDetaljer
   initialDeltakere: Deltakere
   initialStatusCounts: DeltakerStatusCounts
+  initialHandlingCounts: DeltakerHandlingCounts
   children: React.ReactNode
 }) => {
   const [deltakerlisteDetaljer, setDeltakerlisteDetaljer] = useState(
@@ -49,12 +53,14 @@ const DeltakerlisteContextProvider = ({
   )
   const [deltakere, setDelakere] = useState(initialDeltakere)
   const [statusCounts] = useState(initialStatusCounts)
+  const [handlingCounts] = useState(initialHandlingCounts)
   const [filtrerteDeltakere, setFiltrerteDeltakere] = useState(initialDeltakere)
 
   const contextValue: DeltakerListeContextProps = {
     deltakerlisteDetaljer: deltakerlisteDetaljer,
     deltakere: deltakere,
     statusCounts: statusCounts,
+    handlingCounts: handlingCounts,
     filtrerteDeltakere: filtrerteDeltakere,
     setDeltakerlisteDetaljer: setDeltakerlisteDetaljer,
     setDeltakere: setDelakere,

--- a/apps/tiltakskoordinator-flate/src/context-providers/FilterContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/FilterContext.tsx
@@ -5,7 +5,7 @@ import {
   StatusFilterValg
 } from '../utils/filter-deltakerliste'
 
-const DEFAULT_STATUS_FILTERS: StatusFilterValg[] = [
+export const DEFAULT_STATUS_FILTERS: StatusFilterValg[] = [
   DeltakerStatusType.VENTER_PA_OPPSTART,
   DeltakerStatusType.DELTAR
 ]

--- a/apps/tiltakskoordinator-flate/src/context-providers/FilterContext.tsx
+++ b/apps/tiltakskoordinator-flate/src/context-providers/FilterContext.tsx
@@ -1,8 +1,14 @@
 import { createContext, useContext, useState } from 'react'
+import { DeltakerStatusType } from 'deltaker-flate-common'
 import {
   HandlingFilterValg,
   StatusFilterValg
 } from '../utils/filter-deltakerliste'
+
+const DEFAULT_STATUS_FILTERS: StatusFilterValg[] = [
+  DeltakerStatusType.VENTER_PA_OPPSTART,
+  DeltakerStatusType.DELTAR
+]
 
 export interface FilterContextProps {
   valgteHendelseFilter: HandlingFilterValg[]
@@ -36,11 +42,11 @@ const FilterContextProvider = ({ children }: { children: React.ReactNode }) => {
   >([])
   const [valgteStatusFilter, setValgteStatusFilter] = useState<
     StatusFilterValg[]
-  >([])
+  >(DEFAULT_STATUS_FILTERS)
 
   const nullstillFilter = () => {
     setValgteHendelseFilter([])
-    setValgteStatusFilter([])
+    setValgteStatusFilter(DEFAULT_STATUS_FILTERS)
   }
 
   const contextValue: FilterContextProps = {

--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
@@ -39,20 +39,15 @@ export const useDeltakerSortering = (
     sortKey: ScopedSortState['orderBy'],
     onSortChanged?: (newSort: ScopedSortState) => void
   ) => {
-    const newSort =
-      sort && sortKey === sort.orderBy && sort.direction === 'descending'
-        ? undefined
-        : {
-            orderBy: sortKey,
-            direction:
-              sort && sortKey === sort.orderBy && sort.direction === 'ascending'
-                ? 'descending'
-                : 'ascending'
-          }
-    // @ts-expect-error newSort er riktig
+    const newSort: ScopedSortState = {
+      orderBy: sortKey,
+      direction:
+        sort && sortKey === sort.orderBy && sort.direction === 'descending'
+          ? 'ascending'
+          : 'descending'
+    }
     setSort(newSort)
     if (onSortChanged) {
-      // @ts-expect-error newSort er riktig
       onSortChanged(newSort)
     }
   }

--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
@@ -1,5 +1,5 @@
 import { SortState } from '@navikt/ds-react'
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Deltaker } from '../api/data/deltakerliste'
 
 export interface ScopedSortState extends SortState {
@@ -27,13 +27,10 @@ export const useDeltakerSortering = (
 ) => {
   const initialSort = sorteringsValg ?? DEFAULT_SORT
   const [sort, setSort] = useState<ScopedSortState | undefined>(initialSort)
-  const [sorterteDeltagere, setSorterteDeltagere] = useState<Deltaker[]>(
-    sorterDeltakere(deltakere, initialSort)
+  const sorterteDeltagere = useMemo(
+    () => sorterDeltakere(deltakere, sort),
+    [deltakere, sort]
   )
-
-  useEffect(() => {
-    setSorterteDeltagere(sorterDeltakere(deltakere, sort))
-  }, [deltakere, sort])
 
   const handleSort = (
     sortKey: ScopedSortState['orderBy'],

--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
@@ -16,13 +16,19 @@ export enum SortKey {
   SLUTT_DATO = 'sluttdato'
 }
 
+const DEFAULT_SORT: ScopedSortState = {
+  orderBy: SortKey.SOKT_INN_DATO,
+  direction: 'descending'
+}
+
 export const useDeltakerSortering = (
   deltakere: Deltaker[],
   sorteringsValg?: ScopedSortState
 ) => {
-  const [sort, setSort] = useState<ScopedSortState | undefined>(sorteringsValg)
+  const initialSort = sorteringsValg ?? DEFAULT_SORT
+  const [sort, setSort] = useState<ScopedSortState | undefined>(initialSort)
   const [sorterteDeltagere, setSorterteDeltagere] = useState<Deltaker[]>(
-    sorterDeltakere(deltakere)
+    sorterDeltakere(deltakere, initialSort)
   )
 
   useEffect(() => {

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.test.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.test.ts
@@ -117,8 +117,11 @@ describe('MockHandler.getDeltakereStatusCounts', () => {
     })
     const body = await response.json()
 
-    expect(body.DELTAR).toBeTypeOf('number')
-    expect(body.HAR_SLUTTET).toBeTypeOf('number')
+    expect(body.statusCounts.DELTAR).toBeTypeOf('number')
+    expect(body.statusCounts.HAR_SLUTTET).toBeTypeOf('number')
+    expect(body.handlingCounts.AktiveForslag).toBeTypeOf('number')
+    expect(body.handlingCounts.OppdateringFraNav).toBeTypeOf('number')
+    expect(body.handlingCounts.NyeDeltakere).toBeTypeOf('number')
   })
 
   it('returnerer 403 ved manglende tilgang', async () => {

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.test.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.test.ts
@@ -1,0 +1,104 @@
+import { DeltakerStatusType } from 'deltaker-flate-common'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { MockHandler } from './MockHandler'
+import { createMockDeltakere } from './mockData'
+
+describe('MockHandler.postDeltakere', () => {
+  let handler: MockHandler
+
+  beforeEach(() => {
+    handler = new MockHandler()
+    handler.mockDeltakere = createMockDeltakere()
+  })
+
+  it('returnerer alle deltakere når ingen filtre er oppgitt', async () => {
+    const response = handler.postDeltakere({})
+    const body = await response.json()
+    expect(body).toHaveLength(handler.mockDeltakere.length)
+  })
+
+  it('filtrerer på harForslagFraArrangor=true', async () => {
+    const deltakeremedForslag = handler.mockDeltakere.filter(
+      (d) => d.harAktiveForslag
+    )
+    const response = handler.postDeltakere({ harForslagFraArrangor: true })
+    const body = await response.json()
+    expect(body).toHaveLength(deltakeremedForslag.length)
+    body.forEach((d: { harAktiveForslag: boolean }) => {
+      expect(d.harAktiveForslag).toBe(true)
+    })
+  })
+
+  it('filtrerer ikke på harForslagFraArrangor=false', async () => {
+    const response = handler.postDeltakere({ harForslagFraArrangor: false })
+    const body = await response.json()
+    expect(body).toHaveLength(handler.mockDeltakere.length)
+  })
+
+  it('filtrerer på én status', async () => {
+    const forventetAntall = handler.mockDeltakere.filter(
+      (d) => d.status.type === DeltakerStatusType.DELTAR
+    ).length
+    const response = handler.postDeltakere({
+      statuser: [DeltakerStatusType.DELTAR]
+    })
+    const body = await response.json()
+    expect(body).toHaveLength(forventetAntall)
+    body.forEach((d: { status: { type: string } }) => {
+      expect(d.status.type).toBe(DeltakerStatusType.DELTAR)
+    })
+  })
+
+  it('filtrerer på flere statuser (OR-logikk)', async () => {
+    const forventetAntall = handler.mockDeltakere.filter(
+      (d) =>
+        d.status.type === DeltakerStatusType.DELTAR ||
+        d.status.type === DeltakerStatusType.SOKT_INN
+    ).length
+    const response = handler.postDeltakere({
+      statuser: [DeltakerStatusType.DELTAR, DeltakerStatusType.SOKT_INN]
+    })
+    const body = await response.json()
+    expect(body).toHaveLength(forventetAntall)
+  })
+
+  it('kombinerer harForslagFraArrangor og statuser (AND-logikk)', async () => {
+    const forventetAntall = handler.mockDeltakere.filter(
+      (d) =>
+        d.harAktiveForslag &&
+        d.status.type === DeltakerStatusType.VENTER_PA_OPPSTART
+    ).length
+    const response = handler.postDeltakere({
+      harForslagFraArrangor: true,
+      statuser: [DeltakerStatusType.VENTER_PA_OPPSTART]
+    })
+    const body = await response.json()
+    expect(body).toHaveLength(forventetAntall)
+  })
+
+  it('returnerer tom liste når ingen matcher statusfilter', async () => {
+    const response = handler.postDeltakere({
+      statuser: [DeltakerStatusType.UTKAST_TIL_PAMELDING]
+    })
+    const body = await response.json()
+    expect(body).toHaveLength(0)
+  })
+
+  it('returnerer 401 når harAdRolle=false', async () => {
+    handler.harAdRolle = false
+    const response = handler.postDeltakere({})
+    expect(response.status).toBe(401)
+  })
+
+  it('returnerer 403 når tilgang=false', async () => {
+    handler.tilgang = false
+    const response = handler.postDeltakere({})
+    expect(response.status).toBe(403)
+  })
+
+  it('returnerer 410 når stengt=true', async () => {
+    handler.stengt = true
+    const response = handler.postDeltakere({})
+    expect(response.status).toBe(410)
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.test.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.test.ts
@@ -102,3 +102,30 @@ describe('MockHandler.postDeltakere', () => {
     expect(response.status).toBe(410)
   })
 })
+
+describe('MockHandler.getDeltakereStatusCounts', () => {
+  let handler: MockHandler
+
+  beforeEach(() => {
+    handler = new MockHandler()
+    handler.mockDeltakere = createMockDeltakere()
+  })
+
+  it('returnerer tellinger for forespurte statuser', async () => {
+    const response = handler.getDeltakereStatusCounts({
+      statuser: [DeltakerStatusType.DELTAR, DeltakerStatusType.HAR_SLUTTET]
+    })
+    const body = await response.json()
+
+    expect(body.DELTAR).toBeTypeOf('number')
+    expect(body.HAR_SLUTTET).toBeTypeOf('number')
+  })
+
+  it('returnerer 403 ved manglende tilgang', async () => {
+    handler.tilgang = false
+    const response = handler.getDeltakereStatusCounts({
+      statuser: [DeltakerStatusType.DELTAR]
+    })
+    expect(response.status).toBe(403)
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
@@ -44,6 +44,41 @@ export class MockHandler {
     return HttpResponse.json(mapMockDeltakereToDeltakere(this.mockDeltakere))
   }
 
+  postDeltakere(request: {
+    harForslagFraArrangor?: boolean
+    statuser?: DeltakerStatusType[]
+  }) {
+    if (this.stengt) {
+      return HttpResponse.json(
+        { error: 'Deltakerliste stengt' },
+        { status: 410 }
+      )
+    }
+    if (!this.harAdRolle) {
+      return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (!this.tilgang) {
+      return HttpResponse.json({ error: 'Not Authorized' }, { status: 403 })
+    }
+
+    let filtrerteDeltakere = this.mockDeltakere
+
+    if (request.harForslagFraArrangor) {
+      filtrerteDeltakere = filtrerteDeltakere.filter(
+        (deltaker) => deltaker.harAktiveForslag
+      )
+    }
+
+    if ((request.statuser?.length ?? 0) > 0) {
+      const valgteStatuser = new Set(request.statuser)
+      filtrerteDeltakere = filtrerteDeltakere.filter((deltaker) =>
+        valgteStatuser.has(deltaker.status.type)
+      )
+    }
+
+    return HttpResponse.json(mapMockDeltakereToDeltakere(filtrerteDeltakere))
+  }
+
   getDeltaker(deltakerId: string) {
     if (this.stengt) {
       return HttpResponse.json(
@@ -118,13 +153,12 @@ export class MockHandler {
   }
 
   delMedArrangor(delteDeltakerIder: string[]) {
-    const oppdaterteDeltakere = this.mockDeltakere.map((deltaker) => {
+    this.mockDeltakere = this.mockDeltakere.map((deltaker) => {
       if (delteDeltakerIder.includes(deltaker.id)) {
         deltaker.erManueltDeltMedArrangor = true
       }
       return deltaker
     })
-    this.mockDeltakere = oppdaterteDeltakere
 
     return HttpResponse.json(
       mapMockDeltakereToDeltakere(
@@ -136,7 +170,7 @@ export class MockHandler {
   }
 
   tildelPlass(delteDeltakerIder: string[]) {
-    const oppdaterteDeltakere = this.mockDeltakere.map((deltaker) => {
+    this.mockDeltakere = this.mockDeltakere.map((deltaker) => {
       if (delteDeltakerIder.includes(deltaker.id)) {
         deltaker.status.type = DeltakerStatusType.VENTER_PA_OPPSTART
         deltaker.status.aarsak = null
@@ -144,7 +178,6 @@ export class MockHandler {
       deltaker.feilkode = null
       return deltaker
     })
-    this.mockDeltakere = oppdaterteDeltakere
 
     return HttpResponse.json(
       mapMockDeltakereToDeltakere(
@@ -156,7 +189,7 @@ export class MockHandler {
   }
 
   settPaVenteliste(delteDeltakerIder: string[]) {
-    const oppdaterteDeltakere = this.mockDeltakere.map((deltaker) => {
+    this.mockDeltakere = this.mockDeltakere.map((deltaker) => {
       if (delteDeltakerIder.includes(deltaker.id)) {
         deltaker.status.aarsak = null
         deltaker.feilkode = [Feilkode.MIDLERTIDIG_FEIL, null][
@@ -169,7 +202,6 @@ export class MockHandler {
       }
       return deltaker
     })
-    this.mockDeltakere = oppdaterteDeltakere
 
     return HttpResponse.json(
       mapMockDeltakereToDeltakere(

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
@@ -79,7 +79,10 @@ export class MockHandler {
     return HttpResponse.json(mapMockDeltakereToDeltakere(filtrerteDeltakere))
   }
 
-  getDeltakereStatusCounts(request: { statuser?: DeltakerStatusType[] }) {
+  getDeltakereStatusCounts(request: {
+    harForslagFraArrangor?: boolean
+    statuser?: DeltakerStatusType[]
+  }) {
     if (this.stengt) {
       return HttpResponse.json(
         { error: 'Deltakerliste stengt' },
@@ -93,16 +96,36 @@ export class MockHandler {
       return HttpResponse.json({ error: 'Not Authorized' }, { status: 403 })
     }
 
+    let filtrerteDeltakere = this.mockDeltakere
+
+    if (request.harForslagFraArrangor) {
+      filtrerteDeltakere = filtrerteDeltakere.filter(
+        (deltaker) => deltaker.harAktiveForslag
+      )
+    }
+
     const statuser = request.statuser ?? []
-    const counts = Object.fromEntries(
+    const statusCounts = Object.fromEntries(
       statuser.map((status) => [
         status,
-        this.mockDeltakere.filter((deltaker) => deltaker.status.type === status)
+        filtrerteDeltakere.filter((deltaker) => deltaker.status.type === status)
           .length
       ])
     )
 
-    return HttpResponse.json(counts)
+    const handlingCounts = {
+      AktiveForslag: filtrerteDeltakere.filter(
+        (deltaker) => deltaker.harAktiveForslag
+      ).length,
+      OppdateringFraNav: filtrerteDeltakere.filter(
+        (deltaker) => deltaker.harOppdateringFraNav
+      ).length,
+      NyeDeltakere: filtrerteDeltakere.filter(
+        (deltaker) => deltaker.erNyDeltaker
+      ).length
+    }
+
+    return HttpResponse.json({ statusCounts, handlingCounts })
   }
 
   getDeltaker(deltakerId: string) {

--- a/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/MockHandler.ts
@@ -79,6 +79,32 @@ export class MockHandler {
     return HttpResponse.json(mapMockDeltakereToDeltakere(filtrerteDeltakere))
   }
 
+  getDeltakereStatusCounts(request: { statuser?: DeltakerStatusType[] }) {
+    if (this.stengt) {
+      return HttpResponse.json(
+        { error: 'Deltakerliste stengt' },
+        { status: 410 }
+      )
+    }
+    if (!this.harAdRolle) {
+      return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (!this.tilgang) {
+      return HttpResponse.json({ error: 'Not Authorized' }, { status: 403 })
+    }
+
+    const statuser = request.statuser ?? []
+    const counts = Object.fromEntries(
+      statuser.map((status) => [
+        status,
+        this.mockDeltakere.filter((deltaker) => deltaker.status.type === status)
+          .length
+      ])
+    )
+
+    return HttpResponse.json(counts)
+  }
+
   getDeltaker(deltakerId: string) {
     if (this.stengt) {
       return HttpResponse.json(

--- a/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
@@ -45,6 +45,15 @@ export const worker = setupWorker(
       return handler.postDeltakere(body)
     }
   ),
+  http.post(
+    '/amt-deltaker-bff/tiltakskoordinator/deltakerliste/:deltakerlisteId/deltakere/status-counts',
+    async ({ request }) => {
+      await delay(500)
+      const body =
+        (await request.json()) as TiltaksKoordinatorDeltakerlisteRequest
+      return handler.getDeltakereStatusCounts(body)
+    }
+  ),
   http.get(
     '/amt-deltaker-bff/tiltakskoordinator/deltakerliste/:deltakerlisteId/deltakere',
     async () => {

--- a/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
@@ -1,5 +1,6 @@
 import {
   DeltakerStatusAarsak,
+  DeltakerStatusType,
   KOMET_ER_MASTER,
   LES_ARENA_DELTAKERE_TOGGLE_NAVN,
   Oppstartstype,
@@ -33,6 +34,17 @@ export const worker = setupWorker(
     async () => {
       await delay(500)
       return handler.getDeltakerlisteDetaljer()
+    }
+  ),
+  http.post(
+    '/amt-deltaker-bff/tiltakskoordinator/deltakerliste/:deltakerlisteId/deltakere-paged',
+    async ({ request }) => {
+      await delay(500)
+      const body = (await request.json()) as {
+        harForslagFraArrangor?: boolean
+        statuser?: DeltakerStatusType[]
+      }
+      return handler.postDeltakere(body)
     }
   ),
   http.get(

--- a/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
@@ -1,6 +1,5 @@
 import {
   DeltakerStatusAarsak,
-  DeltakerStatusType,
   KOMET_ER_MASTER,
   LES_ARENA_DELTAKERE_TOGGLE_NAVN,
   Oppstartstype,
@@ -8,6 +7,7 @@ import {
 } from 'deltaker-flate-common'
 import { delay, http, HttpResponse } from 'msw'
 import { setupWorker } from 'msw/browser'
+import { TiltaksKoordinatorDeltakerlisteRequest } from '../api/data/deltakerliste'
 import { MockHandler } from './MockHandler'
 
 const handler = new MockHandler()
@@ -40,10 +40,8 @@ export const worker = setupWorker(
     '/amt-deltaker-bff/tiltakskoordinator/deltakerliste/:deltakerlisteId/deltakere-paged',
     async ({ request }) => {
       await delay(500)
-      const body = (await request.json()) as {
-        harForslagFraArrangor?: boolean
-        statuser?: DeltakerStatusType[]
-      }
+      const body =
+        (await request.json()) as TiltaksKoordinatorDeltakerlisteRequest
       return handler.postDeltakere(body)
     }
   ),

--- a/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
+++ b/apps/tiltakskoordinator-flate/src/mocks/setupMocks.ts
@@ -37,7 +37,7 @@ export const worker = setupWorker(
     }
   ),
   http.post(
-    '/amt-deltaker-bff/tiltakskoordinator/deltakerliste/:deltakerlisteId/deltakere-paged',
+    '/amt-deltaker-bff/tiltakskoordinator/deltakerliste/:deltakerlisteId/deltakere',
     async ({ request }) => {
       await delay(500)
       const body =

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -21,13 +21,12 @@ export const DeltakerlistePage = () => {
 
   const request = useMemo(
     () => ({
-      gjennomforingId: deltakerlisteDetaljer.id,
       harForslagFraArrangor: valgteHendelseFilter.includes(
         HandlingFilterValg.AktiveForslag
       ),
       statuser: valgteStatusFilter
     }),
-    [deltakerlisteDetaljer.id, valgteHendelseFilter, valgteStatusFilter]
+    [valgteHendelseFilter, valgteStatusFilter]
   )
 
   const { data: deltakereResponse } = useQuery({

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -1,6 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { Alert, Loader } from '@navikt/ds-react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getDeltakere } from '../api/api'
 import { DeltakerlisteDetaljer } from '../components/DeltakerlisteDetaljer'
@@ -33,6 +33,7 @@ export const DeltakerlistePage = () => {
   const {
     data: deltakereResponse,
     isFetching,
+    isPlaceholderData,
     error
   } = useQuery({
     queryKey: [
@@ -41,20 +42,26 @@ export const DeltakerlistePage = () => {
       request.harForslagFraArrangor,
       request.statuser
     ],
-    queryFn: async () => {
-      const response = await getDeltakere(deltakerlisteDetaljer.id, request)
-      if (!isTilgangsFeil(response)) {
-        setDeltakere(response)
-      }
-      return response
-    },
+    queryFn: async () => getDeltakere(deltakerlisteDetaljer.id, request),
     staleTime: 0,
     placeholderData: keepPreviousData
   })
 
-  if (deltakereResponse && isTilgangsFeil(deltakereResponse)) {
-    handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
-  }
+  useEffect(() => {
+    if (
+      !isPlaceholderData &&
+      deltakereResponse &&
+      !isTilgangsFeil(deltakereResponse)
+    ) {
+      setDeltakere(deltakereResponse)
+    }
+  }, [deltakereResponse, isPlaceholderData, setDeltakere])
+
+  useEffect(() => {
+    if (deltakereResponse && isTilgangsFeil(deltakereResponse)) {
+      handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
+    }
+  }, [deltakereResponse, deltakerlisteId, navigate])
 
   return (
     <div className="flex flex-wrap p-4 pt-0" data-testid="page_deltakerliste">

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -18,7 +18,8 @@ export const DeltakerlistePage = () => {
   const { deltakerlisteId } = useAppContext()
   const navigate = useNavigate()
   const { valgteHendelseFilter, valgteStatusFilter } = useFilterContext()
-  const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
+  const { deltakerlisteDetaljer, deltakere, setDeltakere } =
+    useDeltakerlisteContext()
 
   const request = useMemo(
     () => ({
@@ -42,6 +43,8 @@ export const DeltakerlistePage = () => {
       request.statuser
     ],
     queryFn: () => getDeltakere(deltakerlisteDetaljer.id, request),
+    initialData: deltakere,
+    staleTime: 60 * 1000, // 1 minutt
     placeholderData: keepPreviousData
   })
 

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { Alert, Loader } from '@navikt/ds-react'
 import { useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getDeltakere } from '../api/api'
@@ -29,14 +30,19 @@ export const DeltakerlistePage = () => {
     [valgteHendelseFilter, valgteStatusFilter]
   )
 
-  const { data: deltakereResponse } = useQuery({
+  const {
+    data: deltakereResponse,
+    isFetching,
+    error
+  } = useQuery({
     queryKey: [
       'deltakere',
       deltakerlisteDetaljer.id,
-      valgteHendelseFilter,
-      valgteStatusFilter
+      request.harForslagFraArrangor,
+      request.statuser
     ],
-    queryFn: () => getDeltakere(deltakerlisteDetaljer.id, request)
+    queryFn: () => getDeltakere(deltakerlisteDetaljer.id, request),
+    placeholderData: keepPreviousData
   })
 
   useEffect(() => {
@@ -64,6 +70,18 @@ export const DeltakerlistePage = () => {
 
       <div className="flex-1 min-w-0">
         <h2 className="sr-only">Deltakerliste</h2>
+        {error && (
+          <Alert variant="error" size="small" className="mt-4">
+            Kunne ikke hente deltakere. Prøv igjen senere.
+          </Alert>
+        )}
+        {isFetching && (
+          <Loader
+            size="small"
+            title="Laster deltakere..."
+            className="mt-4 mb-2"
+          />
+        )}
         <DeltakerlisteTabell />
       </div>
     </div>

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -8,10 +8,7 @@ import { DeltakerlisteTabell } from '../components/deltaker-liste-tabell/Deltake
 import { FilterDeltakerliste } from '../components/filter-deltakerliste/FilterDeltakerliste'
 import { useAppContext } from '../context-providers/AppContext'
 import { useDeltakerlisteContext } from '../context-providers/DeltakerlisteContext'
-import {
-  DEFAULT_STATUS_FILTERS,
-  useFilterContext
-} from '../context-providers/FilterContext'
+import { useFilterContext } from '../context-providers/FilterContext'
 import { useFocusPageLoad } from '../hooks/useFocusPageLoad'
 import { HandlingFilterValg } from '../utils/filter-deltakerliste'
 import { handterTilgangsFeil, isTilgangsFeil } from '../utils/tilgangsFeil'
@@ -21,8 +18,7 @@ export const DeltakerlistePage = () => {
   const { deltakerlisteId } = useAppContext()
   const navigate = useNavigate()
   const { valgteHendelseFilter, valgteStatusFilter } = useFilterContext()
-  const { deltakerlisteDetaljer, deltakere, setDeltakere } =
-    useDeltakerlisteContext()
+  const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
 
   const request = useMemo(
     () => ({
@@ -33,15 +29,6 @@ export const DeltakerlistePage = () => {
     }),
     [valgteHendelseFilter, valgteStatusFilter]
   )
-
-  const harDefaultStatuser =
-    valgteStatusFilter.length === DEFAULT_STATUS_FILTERS.length &&
-    DEFAULT_STATUS_FILTERS.every((status) =>
-      valgteStatusFilter.includes(status)
-    )
-
-  const erInitialtFiltervalg =
-    !request.harForslagFraArrangor && harDefaultStatuser
 
   const {
     data: deltakereResponse,
@@ -61,7 +48,6 @@ export const DeltakerlistePage = () => {
       }
       return response
     },
-    initialData: erInitialtFiltervalg ? deltakere : undefined,
     staleTime: 60 * 1000, // 1 minutt
     placeholderData: keepPreviousData
   })

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -8,7 +8,10 @@ import { DeltakerlisteTabell } from '../components/deltaker-liste-tabell/Deltake
 import { FilterDeltakerliste } from '../components/filter-deltakerliste/FilterDeltakerliste'
 import { useAppContext } from '../context-providers/AppContext'
 import { useDeltakerlisteContext } from '../context-providers/DeltakerlisteContext'
-import { useFilterContext } from '../context-providers/FilterContext'
+import {
+  DEFAULT_STATUS_FILTERS,
+  useFilterContext
+} from '../context-providers/FilterContext'
 import { useFocusPageLoad } from '../hooks/useFocusPageLoad'
 import { HandlingFilterValg } from '../utils/filter-deltakerliste'
 import { handterTilgangsFeil, isTilgangsFeil } from '../utils/tilgangsFeil'
@@ -31,6 +34,15 @@ export const DeltakerlistePage = () => {
     [valgteHendelseFilter, valgteStatusFilter]
   )
 
+  const harDefaultStatuser =
+    valgteStatusFilter.length === DEFAULT_STATUS_FILTERS.length &&
+    DEFAULT_STATUS_FILTERS.every((status) =>
+      valgteStatusFilter.includes(status)
+    )
+
+  const erInitialtFiltervalg =
+    !request.harForslagFraArrangor && harDefaultStatuser
+
   const {
     data: deltakereResponse,
     isFetching,
@@ -43,7 +55,7 @@ export const DeltakerlistePage = () => {
       request.statuser
     ],
     queryFn: () => getDeltakere(deltakerlisteDetaljer.id, request),
-    initialData: deltakere,
+    initialData: erInitialtFiltervalg ? deltakere : undefined,
     staleTime: 60 * 1000, // 1 minutt
     placeholderData: keepPreviousData
   })

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -48,7 +48,7 @@ export const DeltakerlistePage = () => {
       }
       return response
     },
-    staleTime: 60 * 1000, // 1 minutt
+    staleTime: 0,
     placeholderData: keepPreviousData
   })
 

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -43,6 +43,7 @@ export const DeltakerlistePage = () => {
 
   const {
     data: deltakereResponse,
+    isPending,
     isFetching,
     isPlaceholderData,
     error
@@ -98,7 +99,7 @@ export const DeltakerlistePage = () => {
             className="mt-4 mb-2"
           />
         )}
-        <DeltakerlisteTabell />
+        {!isPending && <DeltakerlisteTabell />}
       </div>
     </div>
   )

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -1,10 +1,57 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getDeltakere } from '../api/api'
 import { DeltakerlisteDetaljer } from '../components/DeltakerlisteDetaljer'
 import { DeltakerlisteTabell } from '../components/deltaker-liste-tabell/DeltakerlisteTabell'
 import { FilterDeltakerliste } from '../components/filter-deltakerliste/FilterDeltakerliste'
+import { useAppContext } from '../context-providers/AppContext'
+import { useDeltakerlisteContext } from '../context-providers/DeltakerlisteContext'
+import { useFilterContext } from '../context-providers/FilterContext'
 import { useFocusPageLoad } from '../hooks/useFocusPageLoad'
+import { HandlingFilterValg } from '../utils/filter-deltakerliste'
+import { handterTilgangsFeil, isTilgangsFeil } from '../utils/tilgangsFeil'
 
 export const DeltakerlistePage = () => {
   const { ref } = useFocusPageLoad('Deltakerliste')
+  const { deltakerlisteId } = useAppContext()
+  const navigate = useNavigate()
+  const { valgteHendelseFilter, valgteStatusFilter } = useFilterContext()
+  const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
+
+  const request = useMemo(
+    () => ({
+      gjennomforingId: deltakerlisteDetaljer.id,
+      harForslagFraArrangor: valgteHendelseFilter.includes(
+        HandlingFilterValg.AktiveForslag
+      ),
+      statuser: valgteStatusFilter
+    }),
+    [deltakerlisteDetaljer.id, valgteHendelseFilter, valgteStatusFilter]
+  )
+
+  const { data: deltakereResponse } = useQuery({
+    queryKey: [
+      'deltakere',
+      deltakerlisteDetaljer.id,
+      valgteHendelseFilter,
+      valgteStatusFilter
+    ],
+    queryFn: () => getDeltakere(deltakerlisteDetaljer.id, request)
+  })
+
+  useEffect(() => {
+    if (!deltakereResponse) {
+      return
+    }
+
+    if (isTilgangsFeil(deltakereResponse)) {
+      handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
+      return
+    }
+
+    setDeltakere(deltakereResponse)
+  }, [deltakereResponse, deltakerlisteId, navigate, setDeltakere])
 
   return (
     <div className="flex flex-wrap p-4 pt-0" data-testid="page_deltakerliste">

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -10,7 +10,10 @@ import { useAppContext } from '../context-providers/AppContext'
 import { useDeltakerlisteContext } from '../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../context-providers/FilterContext'
 import { useFocusPageLoad } from '../hooks/useFocusPageLoad'
-import { HandlingFilterValg } from '../utils/filter-deltakerliste'
+import {
+  HandlingFilterValg,
+  STATUS_FILTER_TYPER
+} from '../utils/filter-deltakerliste'
 import { handterTilgangsFeil, isTilgangsFeil } from '../utils/tilgangsFeil'
 
 export const DeltakerlistePage = () => {
@@ -20,14 +23,22 @@ export const DeltakerlistePage = () => {
   const { valgteHendelseFilter, valgteStatusFilter } = useFilterContext()
   const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
 
+  const normaliserteStatuser = useMemo(
+    () =>
+      STATUS_FILTER_TYPER.filter((status) =>
+        valgteStatusFilter.includes(status)
+      ),
+    [valgteStatusFilter]
+  )
+
   const request = useMemo(
     () => ({
       harForslagFraArrangor: valgteHendelseFilter.includes(
         HandlingFilterValg.AktiveForslag
       ),
-      statuser: valgteStatusFilter
+      statuser: normaliserteStatuser
     }),
-    [valgteHendelseFilter, valgteStatusFilter]
+    [valgteHendelseFilter, normaliserteStatuser]
   )
 
   const {

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -1,6 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { Alert, Loader } from '@navikt/ds-react'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getDeltakere } from '../api/api'
 import { DeltakerlisteDetaljer } from '../components/DeltakerlisteDetaljer'
@@ -54,24 +54,21 @@ export const DeltakerlistePage = () => {
       request.harForslagFraArrangor,
       request.statuser
     ],
-    queryFn: () => getDeltakere(deltakerlisteDetaljer.id, request),
+    queryFn: async () => {
+      const response = await getDeltakere(deltakerlisteDetaljer.id, request)
+      if (!isTilgangsFeil(response)) {
+        setDeltakere(response)
+      }
+      return response
+    },
     initialData: erInitialtFiltervalg ? deltakere : undefined,
     staleTime: 60 * 1000, // 1 minutt
     placeholderData: keepPreviousData
   })
 
-  useEffect(() => {
-    if (!deltakereResponse) {
-      return
-    }
-
-    if (isTilgangsFeil(deltakereResponse)) {
-      handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
-      return
-    }
-
-    setDeltakere(deltakereResponse)
-  }, [deltakereResponse, deltakerlisteId, navigate, setDeltakere])
+  if (deltakereResponse && isTilgangsFeil(deltakereResponse)) {
+    handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
+  }
 
   return (
     <div className="flex flex-wrap p-4 pt-0" data-testid="page_deltakerliste">

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -92,14 +92,22 @@ export const DeltakerlistePage = () => {
             Kunne ikke hente deltakere. Prøv igjen senere.
           </Alert>
         )}
-        {isFetching && (
+        {isPending && (
           <Loader
             size="small"
             title="Laster deltakere..."
             className="mt-4 mb-2"
           />
         )}
-        {!isPending && <DeltakerlisteTabell />}
+        {!isPending && (
+          <div
+            className={
+              isFetching ? 'opacity-50 transition-opacity duration-150' : ''
+            }
+          >
+            <DeltakerlisteTabell />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/tiltakskoordinator-flate/src/queryClient.ts
+++ b/apps/tiltakskoordinator-flate/src/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 3,
+      refetchOnWindowFocus: false
+    }
+  }
+})

--- a/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.ts
@@ -49,7 +49,7 @@ export const getFilterStatuser = (
   return statuser
 }
 
-const statusFilterTyper = [
+export const STATUS_FILTER_TYPER = [
   DeltakerStatusType.SOKT_INN,
   DeltakerStatusType.VENTELISTE,
   DeltakerStatusType.VENTER_PA_OPPSTART,
@@ -60,7 +60,7 @@ const statusFilterTyper = [
   DeltakerStatusType.IKKE_AKTUELL
 ] as const
 
-export type StatusFilterValg = (typeof statusFilterTyper)[number]
+export type StatusFilterValg = (typeof STATUS_FILTER_TYPER)[number]
 
 const getHandlingFilterTypeNavn = (filterValg: HandlingFilterValg): string => {
   switch (filterValg) {
@@ -196,7 +196,7 @@ export const getStatusFilterDetaljer = (
     deltakere,
     valgteHandlingerFilter
   )
-  return statusFilterTyper.map((filterValg) => {
+  return STATUS_FILTER_TYPER.map((filterValg) => {
     const erValgt = valgteFilter.includes(filterValg)
 
     return {

--- a/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.ts
@@ -62,7 +62,9 @@ export const STATUS_FILTER_TYPER = [
 
 export type StatusFilterValg = (typeof STATUS_FILTER_TYPER)[number]
 
-const getHandlingFilterTypeNavn = (filterValg: HandlingFilterValg): string => {
+export const getHandlingFilterTypeNavn = (
+  filterValg: HandlingFilterValg
+): string => {
   switch (filterValg) {
     case HandlingFilterValg.AktiveForslag:
       return 'Forslag fra arrangør'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@navikt/ds-tailwind':
         specifier: ^8.10.3
         version: 8.10.3
+      '@tanstack/react-query':
+        specifier: ^5.100.6
+        version: 5.100.6(react@19.2.5)
       dayjs:
         specifier: ^1.11.20
         version: 1.11.20
@@ -720,6 +723,9 @@ packages:
       '@types/react': ^17.0.30 || ^18 || ^19
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@navikt/ds-tailwind@8.10.3':
     resolution: {integrity: sha512-oyv1dLdLvnkcavlFOX7oFkWWyl4AKN8iP/OLN9M2lhcqKCNdYSCetty73tzILuoaHneyoxTYPPn2uwIlxHey0Q==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tailwind/8.10.3/dd5ab1e6543ceffb74261a3d2250cd9b167dfdf1}
@@ -733,6 +739,9 @@ packages:
     peerDependencies:
       html-react-parser: '>=5.x'
       react: '>=17.x'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -3262,11 +3271,12 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@navikt/aksel-icons': 8.10.3
       '@navikt/ds-tokens': 8.10.3
-      '@types/react': 19.2.14
       date-fns: 4.1.0
       react: 19.2.5
       react-day-picker: 9.14.0(react@19.2.5)
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@navikt/ds-tailwind@8.10.3': {}
 
@@ -3277,6 +3287,7 @@ snapshots:
       csp-header: 6.3.1
       html-react-parser: 6.0.1(@types/react@19.2.14)(react@19.2.5)
       js-cookie: 3.0.5
+    optionalDependencies:
       react: 19.2.5
 
   '@open-draft/deferred-promise@2.2.0': {}


### PR DESCRIPTION
## Description
Introduserer server-side refetch av deltakerliste når filtre endres i tiltakskoordinator-flaten, ved å gå over til POST-endepunkt og caching/refetch via TanStack React Query.

Changes:

Lagt til TanStack React Query og satt opp QueryClientProvider med felles QueryClient.
Endret henting av deltakere til POST .../deltakere-paged med filter-parametre i body.
Oppdatert mocks og lagt til tester for ny request-schema, API-kall og mock-filtrering.