### PR TITLE
Resetter nå sortering ved endring av filter

### DIFF
--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.test.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { lagMockDeltaker } from '../mocks/mockData'
+import {
+  ScopedSortState,
+  SortKey,
+  useDeltakerSortering
+} from './useDeltakerSortering'
+
+const DEFAULT_SORT: ScopedSortState = {
+  orderBy: SortKey.SOKT_INN_DATO,
+  direction: 'descending'
+}
+
+const NAVN_ASC: ScopedSortState = {
+  orderBy: SortKey.NAVN,
+  direction: 'ascending'
+}
+
+describe('useDeltakerSortering', () => {
+  const deltakere = [lagMockDeltaker(), lagMockDeltaker(), lagMockDeltaker()]
+
+  it('starter med default synkende sortering på Søkt inn', () => {
+    const { result } = renderHook(() =>
+      useDeltakerSortering(deltakere, undefined)
+    )
+
+    expect(result.current.sort).toEqual(DEFAULT_SORT)
+  })
+
+  it('toggler fra descending til ascending på første klikk på aktiv kolonne', () => {
+    const { result } = renderHook(() =>
+      useDeltakerSortering(deltakere, undefined)
+    )
+
+    act(() => {
+      result.current.handleSort(SortKey.SOKT_INN_DATO)
+    })
+
+    expect(result.current.sort).toEqual({
+      orderBy: SortKey.SOKT_INN_DATO,
+      direction: 'ascending'
+    })
+  })
+
+  it('toggler tilbake til descending på andre klikk', () => {
+    const { result } = renderHook(() =>
+      useDeltakerSortering(deltakere, undefined)
+    )
+
+    act(() => {
+      result.current.handleSort(SortKey.SOKT_INN_DATO)
+    })
+    act(() => {
+      result.current.handleSort(SortKey.SOKT_INN_DATO)
+    })
+
+    expect(result.current.sort).toEqual({
+      orderBy: SortKey.SOKT_INN_DATO,
+      direction: 'descending'
+    })
+  })
+
+  it('bytter kolonne og setter descending som default retning', () => {
+    const { result } = renderHook(() =>
+      useDeltakerSortering(deltakere, undefined)
+    )
+
+    act(() => {
+      result.current.handleSort(SortKey.NAVN)
+    })
+
+    expect(result.current.sort).toEqual({
+      orderBy: SortKey.NAVN,
+      direction: 'descending'
+    })
+  })
+
+  it('resetter til default sort når sorteringsValg endres til undefined', () => {
+    let sorteringsValg: ScopedSortState | undefined = NAVN_ASC
+
+    const { result, rerender } = renderHook(() =>
+      useDeltakerSortering(deltakere, sorteringsValg)
+    )
+
+    expect(result.current.sort).toEqual(NAVN_ASC)
+
+    sorteringsValg = undefined
+    rerender()
+
+    expect(result.current.sort).toEqual(DEFAULT_SORT)
+  })
+
+  it('tar i bruk nytt sorteringsValg når prop endres', () => {
+    let sorteringsValg: ScopedSortState | undefined = undefined
+
+    const { result, rerender } = renderHook(() =>
+      useDeltakerSortering(deltakere, sorteringsValg)
+    )
+
+    expect(result.current.sort).toEqual(DEFAULT_SORT)
+
+    sorteringsValg = NAVN_ASC
+    rerender()
+
+    expect(result.current.sort).toEqual(NAVN_ASC)
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
+++ b/apps/tiltakskoordinator-flate/src/hooks/useDeltakerSortering.tsx
@@ -1,5 +1,5 @@
 import { SortState } from '@navikt/ds-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Deltaker } from '../api/data/deltakerliste'
 
 export interface ScopedSortState extends SortState {
@@ -27,6 +27,11 @@ export const useDeltakerSortering = (
 ) => {
   const initialSort = sorteringsValg ?? DEFAULT_SORT
   const [sort, setSort] = useState<ScopedSortState | undefined>(initialSort)
+
+  useEffect(() => {
+    setSort(sorteringsValg ?? DEFAULT_SORT)
+  }, [sorteringsValg])
+
   const sorterteDeltagere = useMemo(
     () => sorterDeltakere(deltakere, sort),
     [deltakere, sort]

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -1,6 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { Alert, Loader } from '@navikt/ds-react'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getDeltakere } from '../api/api'
 import { DeltakerlisteDetaljer } from '../components/DeltakerlisteDetaljer'
@@ -25,6 +25,8 @@ export const DeltakerlistePage = () => {
   const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
   const { setLagretSorteringsValg } = useSorteringContext()
 
+  const erForsteRender = useRef(true)
+
   const normaliserteStatuser = useMemo(
     () =>
       STATUS_FILTER_TYPER.filter((status) =>
@@ -44,6 +46,10 @@ export const DeltakerlistePage = () => {
   )
 
   useEffect(() => {
+    if (erForsteRender.current) {
+      erForsteRender.current = false
+      return
+    }
     setLagretSorteringsValg(undefined)
   }, [request, setLagretSorteringsValg])
 

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -10,6 +10,7 @@ import { useAppContext } from '../context-providers/AppContext'
 import { useDeltakerlisteContext } from '../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../context-providers/FilterContext'
 import { useFocusPageLoad } from '../hooks/useFocusPageLoad'
+import { useSorteringContext } from '../context-providers/SorteringContext'
 import {
   HandlingFilterValg,
   STATUS_FILTER_TYPER
@@ -22,6 +23,7 @@ export const DeltakerlistePage = () => {
   const navigate = useNavigate()
   const { valgteHendelseFilter, valgteStatusFilter } = useFilterContext()
   const { deltakerlisteDetaljer, setDeltakere } = useDeltakerlisteContext()
+  const { setLagretSorteringsValg } = useSorteringContext()
 
   const normaliserteStatuser = useMemo(
     () =>
@@ -40,6 +42,10 @@ export const DeltakerlistePage = () => {
     }),
     [valgteHendelseFilter, normaliserteStatuser]
   )
+
+  useEffect(() => {
+    setLagretSorteringsValg(undefined)
+  }, [request, setLagretSorteringsValg])
 
   const {
     data: deltakereResponse,


### PR DESCRIPTION
## Description
Denne PR-en forsøker å sikre at deltakerlista går tilbake til standard sortering når brukeren endrer filter, ved å nullstille lagret sorteringsvalg og gjøre sorterings-hooken responsiv på endringer i “lagret” sortering i context.

**Changes:**
- Nullstiller lagret sortering i `DeltakerlistePage` når filter-/request-grunnlaget endres.
- Oppdaterer `useDeltakerSortering` slik at intern sort-state resettes når `sorteringsValg`-prop endres.
- Legger til tester for `useDeltakerSortering`, inkludert reset ved endret/undefined `sorteringsValg`.