### PR TITLE
Bug-fix: Tilgang

### DIFF
--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.test.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DeltakerStatusType } from 'deltaker-flate-common'
+import { TilgangsFeil } from '../api/api'
 import { DeltakerlistePage } from './DeltakerlistePage'
 import { HandlingFilterValg } from '../utils/filter-deltakerliste'
 
@@ -10,15 +11,32 @@ let valgteStatusFilter: DeltakerStatusType[] = []
 const setLagretSorteringsValg = vi.fn()
 const setDeltakere = vi.fn()
 
+const mockQueryState = vi.hoisted(() => ({
+  data: undefined as unknown,
+  isFetching: false
+}))
+
+const { handterTilgangsFeilMock } = vi.hoisted(() => ({
+  handterTilgangsFeilMock: vi.fn()
+}))
+
 vi.mock('@tanstack/react-query', () => ({
   keepPreviousData: Symbol('keepPreviousData'),
   useQuery: () => ({
-    data: undefined,
+    data: mockQueryState.data,
     isPending: false,
-    isFetching: false,
+    isFetching: mockQueryState.isFetching,
     isPlaceholderData: false,
     error: null
   })
+}))
+
+vi.mock('../utils/tilgangsFeil', () => ({
+  isTilgangsFeil: (obj: unknown) =>
+    obj === 'ManglerADGruppe' ||
+    obj === 'IkkeTilgangTilDeltakerliste' ||
+    obj === 'DeltakerlisteStengt',
+  handterTilgangsFeil: handterTilgangsFeilMock
 }))
 
 vi.mock('react-router-dom', () => ({
@@ -69,6 +87,8 @@ describe('DeltakerlistePage sort-reset ved filterendring', () => {
     valgteStatusFilter = []
     setLagretSorteringsValg.mockClear()
     setDeltakere.mockClear()
+    mockQueryState.data = undefined
+    mockQueryState.isFetching = false
   })
 
   it('resetter ikke sortering på første render', () => {
@@ -95,5 +115,41 @@ describe('DeltakerlistePage sort-reset ved filterendring', () => {
 
     expect(setLagretSorteringsValg).toHaveBeenCalledTimes(1)
     expect(setLagretSorteringsValg).toHaveBeenCalledWith(undefined)
+  })
+})
+
+describe('DeltakerlistePage tilgangsfeil-håndtering', () => {
+  beforeEach(() => {
+    mockQueryState.data = undefined
+    mockQueryState.isFetching = false
+    handterTilgangsFeilMock.mockClear()
+  })
+
+  it('kaller ikke handterTilgangsFeil når isFetching er true selv om data er TilgangsFeil', () => {
+    mockQueryState.data = TilgangsFeil.IkkeTilgangTilDeltakerliste
+    mockQueryState.isFetching = true
+
+    render(<DeltakerlistePage />)
+
+    expect(handterTilgangsFeilMock).not.toHaveBeenCalled()
+  })
+
+  it('kaller handterTilgangsFeil når isFetching blir false og data er TilgangsFeil', () => {
+    mockQueryState.data = TilgangsFeil.IkkeTilgangTilDeltakerliste
+    mockQueryState.isFetching = true
+
+    const { rerender } = render(<DeltakerlistePage />)
+
+    expect(handterTilgangsFeilMock).not.toHaveBeenCalled()
+
+    mockQueryState.isFetching = false
+    rerender(<DeltakerlistePage />)
+
+    expect(handterTilgangsFeilMock).toHaveBeenCalledTimes(1)
+    expect(handterTilgangsFeilMock).toHaveBeenCalledWith(
+      TilgangsFeil.IkkeTilgangTilDeltakerliste,
+      'liste-id',
+      expect.any(Function)
+    )
   })
 })

--- a/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
+++ b/apps/tiltakskoordinator-flate/src/pages/DeltakerlistePage.tsx
@@ -82,10 +82,10 @@ export const DeltakerlistePage = () => {
   }, [deltakereResponse, isPlaceholderData, setDeltakere])
 
   useEffect(() => {
-    if (deltakereResponse && isTilgangsFeil(deltakereResponse)) {
+    if (!isFetching && deltakereResponse && isTilgangsFeil(deltakereResponse)) {
       handterTilgangsFeil(deltakereResponse, deltakerlisteId, navigate)
     }
-  }, [deltakereResponse, deltakerlisteId, navigate])
+  }, [deltakereResponse, isFetching, deltakerlisteId, navigate])
 
   return (
     <div className="flex flex-wrap p-4 pt-0" data-testid="page_deltakerliste">


### PR DESCRIPTION
## Description
Bug:
- Bruker uten tilgang → 403 → TilgangsFeil lagres i React Query cache
- Bruker registrerer tilgang → navigerer til deltakerliste
- DeltakerlistePage mounter → ser gammel TilgangsFeil fra cache (stale, men fortsatt der)
- useEffect fyrer umiddelbart → navigerer bruker tilbake til tilgangssiden 🐛-
- Bruker prøver igjen → "allerede registrert"

Nytt (fix):
- useEffect sjekker !isFetching — mens refetch pågår ignoreres stale TilgangsFeil
- Når fersk respons kommer inn (200 OK denne gang), er isTilgangsFeil(...) false → ingen navigering
- Hvis responsen fortsatt er 403 etter refetch: isFetching er false → navigerer til tilgangssiden korrekt