### PR TITLE
Refakturert bort duplikatkode i filtre

### DIFF
--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
@@ -1,0 +1,70 @@
+import {
+  BodyShort,
+  Checkbox,
+  CheckboxGroup,
+  ExpansionCard
+} from '@navikt/ds-react'
+import useLocalStorage from '../../../../../packages/deltaker-flate-common/hooks/useLocalStorage'
+
+interface FilterPanelProps<T extends string> {
+  tittel: string
+  ariaLabel: string
+  localStorageKey: string
+  filterAlternativer: { filtervalg: T; navn: string }[]
+  valgteFilter: T[]
+  counts: Partial<Record<T, number>>
+  filterCountsLaster: boolean
+  onChange: (nyValgteFilter: string[]) => void
+}
+
+export const FilterPanel = <T extends string>({
+  tittel,
+  ariaLabel,
+  localStorageKey,
+  filterAlternativer,
+  valgteFilter,
+  counts,
+  filterCountsLaster,
+  onChange
+}: FilterPanelProps<T>) => {
+  const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
+    localStorageKey,
+    false
+  )
+
+  return (
+    <ExpansionCard
+      aria-label={ariaLabel}
+      size="small"
+      open={filterOpen}
+      onToggle={(open: boolean) => setFilterOpen(open)}
+    >
+      <ExpansionCard.Header>
+        <ExpansionCard.Title as="h2" size="small">
+          {tittel}
+        </ExpansionCard.Title>
+      </ExpansionCard.Header>
+
+      <ExpansionCard.Content>
+        <CheckboxGroup
+          size="small"
+          legend=""
+          className="filter-checkboxes -mt-2"
+          onChange={onChange}
+          value={valgteFilter}
+        >
+          {filterAlternativer.map((filter) => (
+            <Checkbox key={filter.filtervalg} value={filter.filtervalg}>
+              <span className="flex justify-between w-full gap-2">
+                <span className="whitespace-nowrap">{filter.navn}</span>
+                <BodyShort as="span" weight="semibold">
+                  {filterCountsLaster ? '-' : (counts[filter.filtervalg] ?? 0)}
+                </BodyShort>
+              </span>
+            </Checkbox>
+          ))}
+        </CheckboxGroup>
+      </ExpansionCard.Content>
+    </ExpansionCard>
+  )
+}

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
@@ -48,7 +48,8 @@ export const FilterPanel = <T extends string>({
       <ExpansionCard.Content>
         <CheckboxGroup
           size="small"
-          legend=""
+          legend={tittel}
+          hideLegend
           className="filter-checkboxes -mt-2"
           onChange={(nyValgteFilter) => onChange(nyValgteFilter as T[])}
           value={valgteFilter}

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
@@ -17,7 +17,7 @@ interface FilterPanelProps<T extends string> {
   onChange: (nyValgteFilter: T[]) => void
 }
 
-export const FilterPanel = <T extends string>({
+export function FilterPanel<T extends string>({
   tittel,
   ariaLabel,
   localStorageKey,
@@ -26,7 +26,7 @@ export const FilterPanel = <T extends string>({
   counts,
   filterCountsLaster,
   onChange
-}: FilterPanelProps<T>) => {
+}: FilterPanelProps<T>) {
   const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
     localStorageKey,
     false

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/FilterPanel.tsx
@@ -14,7 +14,7 @@ interface FilterPanelProps<T extends string> {
   valgteFilter: T[]
   counts: Partial<Record<T, number>>
   filterCountsLaster: boolean
-  onChange: (nyValgteFilter: string[]) => void
+  onChange: (nyValgteFilter: T[]) => void
 }
 
 export const FilterPanel = <T extends string>({
@@ -50,7 +50,7 @@ export const FilterPanel = <T extends string>({
           size="small"
           legend=""
           className="filter-checkboxes -mt-2"
-          onChange={onChange}
+          onChange={(nyValgteFilter) => onChange(nyValgteFilter as T[])}
           value={valgteFilter}
         >
           {filterAlternativer.map((filter) => (

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
@@ -1,29 +1,19 @@
-import {
-  BodyShort,
-  Checkbox,
-  CheckboxGroup,
-  ExpansionCard
-} from '@navikt/ds-react'
 import { kreverGodkjenningForPamelding } from 'deltaker-flate-common'
 import { useMemo } from 'react'
-import useLocalStorage from '../../../../../packages/deltaker-flate-common/hooks/useLocalStorage'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../../context-providers/FilterContext'
 import {
   HandlingFilterValg,
   getHandlingFilterTypeNavn
 } from '../../utils/filter-deltakerliste'
+import { FilterPanel } from './FilterPanel'
 
 export const HendelseFilter = () => {
   const { deltakerlisteDetaljer, handlingCounts, filterCountsLaster } =
     useDeltakerlisteContext()
   const { valgteHendelseFilter, setValgteHendelseFilter } = useFilterContext()
-  const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
-    'deltaker-liste-filter-hendelser-open',
-    false
-  )
 
-  const filterDetaljer = useMemo(() => {
+  const filterAlternativer = useMemo(() => {
     return Object.values(HandlingFilterValg)
       .filter((filterValg) =>
         kreverGodkjenningForPamelding(deltakerlisteDetaljer.pameldingstype)
@@ -36,52 +26,18 @@ export const HendelseFilter = () => {
       }))
   }, [deltakerlisteDetaljer.pameldingstype])
 
-  const handleChange = (nyValgteFilter: string[]) => {
-    setValgteHendelseFilter(
-      nyValgteFilter
-        .filter(
-          (filter): filter is keyof typeof HandlingFilterValg =>
-            filter in HandlingFilterValg
-        )
-        .map((filter) => HandlingFilterValg[filter])
-    )
-  }
-
   return (
-    <ExpansionCard
-      aria-label="Filtrer deltakerliste på hendelser"
-      size="small"
-      open={filterOpen}
-      onToggle={(open: boolean) => setFilterOpen(open)}
-    >
-      <ExpansionCard.Header>
-        <ExpansionCard.Title as="h2" size="small">
-          Hendelser
-        </ExpansionCard.Title>
-      </ExpansionCard.Header>
-
-      <ExpansionCard.Content>
-        <CheckboxGroup
-          size="small"
-          legend=""
-          className="filter-checkboxes -mt-2"
-          onChange={handleChange}
-          value={valgteHendelseFilter}
-        >
-          {filterDetaljer.map((filter) => (
-            <Checkbox key={filter.filtervalg} value={filter.filtervalg}>
-              <span className="flex justify-between w-full gap-2">
-                <span className="whitespace-nowrap">{filter.navn}</span>
-                <BodyShort as="span" weight="semibold">
-                  {filterCountsLaster
-                    ? '-'
-                    : (handlingCounts[filter.filtervalg] ?? 0)}
-                </BodyShort>
-              </span>
-            </Checkbox>
-          ))}
-        </CheckboxGroup>
-      </ExpansionCard.Content>
-    </ExpansionCard>
+    <FilterPanel
+      tittel="Hendelser"
+      ariaLabel="Filtrer deltakerliste på hendelser"
+      localStorageKey="deltaker-liste-filter-hendelser-open"
+      filterAlternativer={filterAlternativer}
+      valgteFilter={valgteHendelseFilter}
+      counts={handlingCounts}
+      filterCountsLaster={filterCountsLaster}
+      onChange={(nyValgteFilter) =>
+        setValgteHendelseFilter(nyValgteFilter as HandlingFilterValg[])
+      }
+    />
   )
 }

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/HendelseFilter.tsx
@@ -35,9 +35,7 @@ export const HendelseFilter = () => {
       valgteFilter={valgteHendelseFilter}
       counts={handlingCounts}
       filterCountsLaster={filterCountsLaster}
-      onChange={(nyValgteFilter) =>
-        setValgteHendelseFilter(nyValgteFilter as HandlingFilterValg[])
-      }
+      onChange={(nyValgteFilter) => setValgteHendelseFilter(nyValgteFilter)}
     />
   )
 }

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -2,7 +2,6 @@ import { getDeltakerStatusDisplayText } from 'deltaker-flate-common'
 import { useMemo } from 'react'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../../context-providers/FilterContext'
-import type { StatusFilterValg } from '../../utils/filter-deltakerliste'
 import { getFilterStatuser } from '../../utils/filter-deltakerliste'
 import { FilterPanel } from './FilterPanel'
 
@@ -39,9 +38,7 @@ export const StatusFilter = () => {
       valgteFilter={valgteStatusFilter}
       counts={statusCounts}
       filterCountsLaster={filterCountsLaster}
-      onChange={(nyValgteFilter) =>
-        setValgteStatusFilter(nyValgteFilter as StatusFilterValg[])
-      }
+      onChange={(nyValgteFilter) => setValgteStatusFilter(nyValgteFilter)}
     />
   )
 }

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -1,27 +1,17 @@
-import {
-  BodyShort,
-  Checkbox,
-  CheckboxGroup,
-  ExpansionCard
-} from '@navikt/ds-react'
 import { getDeltakerStatusDisplayText } from 'deltaker-flate-common'
 import { useMemo } from 'react'
-import useLocalStorage from '../../../../../packages/deltaker-flate-common/hooks/useLocalStorage'
 import { useDeltakerlisteContext } from '../../context-providers/DeltakerlisteContext'
 import { useFilterContext } from '../../context-providers/FilterContext'
 import type { StatusFilterValg } from '../../utils/filter-deltakerliste'
 import { getFilterStatuser } from '../../utils/filter-deltakerliste'
+import { FilterPanel } from './FilterPanel'
 
 export const StatusFilter = () => {
   const { deltakerlisteDetaljer, statusCounts, filterCountsLaster } =
     useDeltakerlisteContext()
   const { valgteStatusFilter, setValgteStatusFilter } = useFilterContext()
-  const [filterOpen, setFilterOpen] = useLocalStorage<boolean>(
-    'deltaker-liste-filter-status-open',
-    false
-  )
 
-  const filtre = useMemo(() => {
+  const filterAlternativer = useMemo(() => {
     return [
       ...new Set(
         getFilterStatuser(
@@ -30,61 +20,28 @@ export const StatusFilter = () => {
           deltakerlisteDetaljer.tiltakskode
         )
       )
-    ]
+    ].map((filtervalg) => ({
+      filtervalg,
+      navn: getDeltakerStatusDisplayText(filtervalg)
+    }))
   }, [
     deltakerlisteDetaljer.oppstartstype,
     deltakerlisteDetaljer.pameldingstype,
     deltakerlisteDetaljer.tiltakskode
   ])
 
-  const filterDetaljer = useMemo(
-    () =>
-      filtre.map((filtervalg) => ({
-        filtervalg,
-        navn: getDeltakerStatusDisplayText(filtervalg)
-      })),
-    [filtre]
-  )
-
-  const handleChange = (nyValgteFilter: string[]) => {
-    setValgteStatusFilter(nyValgteFilter as StatusFilterValg[])
-  }
-
   return (
-    <ExpansionCard
-      aria-label="Filtrer deltakerliste på hendelser"
-      size="small"
-      open={filterOpen}
-      onToggle={(open: boolean) => setFilterOpen(open)}
-    >
-      <ExpansionCard.Header>
-        <ExpansionCard.Title as="h2" size="small">
-          Status
-        </ExpansionCard.Title>
-      </ExpansionCard.Header>
-
-      <ExpansionCard.Content>
-        <CheckboxGroup
-          size="small"
-          legend=""
-          className="filter-checkboxes -mt-2"
-          onChange={handleChange}
-          value={valgteStatusFilter}
-        >
-          {filterDetaljer.map((filter) => (
-            <Checkbox key={filter.filtervalg} value={filter.filtervalg}>
-              <span className="flex justify-between w-full gap-2">
-                <span className="whitespace-nowrap">{filter.navn}</span>
-                <BodyShort as="span" weight="semibold">
-                  {filterCountsLaster
-                    ? '-'
-                    : (statusCounts[filter.filtervalg] ?? 0)}
-                </BodyShort>
-              </span>
-            </Checkbox>
-          ))}
-        </CheckboxGroup>
-      </ExpansionCard.Content>
-    </ExpansionCard>
+    <FilterPanel
+      tittel="Status"
+      ariaLabel="Filtrer deltakerliste på status"
+      localStorageKey="deltaker-liste-filter-status-open"
+      filterAlternativer={filterAlternativer}
+      valgteFilter={valgteStatusFilter}
+      counts={statusCounts}
+      filterCountsLaster={filterCountsLaster}
+      onChange={(nyValgteFilter) =>
+        setValgteStatusFilter(nyValgteFilter as StatusFilterValg[])
+      }
+    />
   )
 }

--- a/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.test.ts
+++ b/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.test.ts
@@ -3,12 +3,6 @@ import { describe, expect, it } from 'vitest'
 import { getDefaultStatusFilter } from './filter-deltakerliste'
 
 describe('getDefaultStatusFilter', () => {
-  it('inkluderer VENTER_PA_OPPSTART og DELTAR for alle pameldingstyper', () => {
-    const result = getDefaultStatusFilter(Pameldingstype.DIREKTE_VEDTAK)
-    expect(result).toContain(DeltakerStatusType.VENTER_PA_OPPSTART)
-    expect(result).toContain(DeltakerStatusType.DELTAR)
-  })
-
   it('inkluderer kun VENTER_PA_OPPSTART og DELTAR for DIREKTE_VEDTAK', () => {
     const result = getDefaultStatusFilter(Pameldingstype.DIREKTE_VEDTAK)
     expect(result).toEqual([

--- a/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.test.ts
+++ b/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.test.ts
@@ -1,0 +1,35 @@
+import { DeltakerStatusType, Pameldingstype } from 'deltaker-flate-common'
+import { describe, expect, it } from 'vitest'
+import { getDefaultStatusFilter } from './filter-deltakerliste'
+
+describe('getDefaultStatusFilter', () => {
+  it('inkluderer VENTER_PA_OPPSTART og DELTAR for alle pameldingstyper', () => {
+    const result = getDefaultStatusFilter(Pameldingstype.DIREKTE_VEDTAK)
+    expect(result).toContain(DeltakerStatusType.VENTER_PA_OPPSTART)
+    expect(result).toContain(DeltakerStatusType.DELTAR)
+  })
+
+  it('inkluderer kun VENTER_PA_OPPSTART og DELTAR for DIREKTE_VEDTAK', () => {
+    const result = getDefaultStatusFilter(Pameldingstype.DIREKTE_VEDTAK)
+    expect(result).toEqual([
+      DeltakerStatusType.VENTER_PA_OPPSTART,
+      DeltakerStatusType.DELTAR
+    ])
+  })
+
+  it('inkluderer SOKT_INN og VENTELISTE for TRENGER_GODKJENNING', () => {
+    const result = getDefaultStatusFilter(Pameldingstype.TRENGER_GODKJENNING)
+    expect(result).toContain(DeltakerStatusType.SOKT_INN)
+    expect(result).toContain(DeltakerStatusType.VENTELISTE)
+  })
+
+  it('setter SOKT_INN og VENTELISTE foran VENTER_PA_OPPSTART og DELTAR for TRENGER_GODKJENNING', () => {
+    const result = getDefaultStatusFilter(Pameldingstype.TRENGER_GODKJENNING)
+    expect(result).toEqual([
+      DeltakerStatusType.SOKT_INN,
+      DeltakerStatusType.VENTELISTE,
+      DeltakerStatusType.VENTER_PA_OPPSTART,
+      DeltakerStatusType.DELTAR
+    ])
+  })
+})

--- a/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/utils/filter-deltakerliste.ts
@@ -17,8 +17,8 @@ export const getFilterStatuser = (
   oppstartstype: Oppstartstype | null,
   pameldingstype: Pameldingstype,
   tiltakskode: Tiltakskode
-) => {
-  const statuser = []
+): StatusFilterValg[] => {
+  const statuser: StatusFilterValg[] = []
 
   if (kreverGodkjenningForPamelding(pameldingstype)) {
     statuser.push(DeltakerStatusType.SOKT_INN, DeltakerStatusType.VENTELISTE)


### PR DESCRIPTION
## Description
Refaktorerer filter-komponentene i tiltakskoordinator-flaten for å fjerne duplikat UI-kode ved å introdusere en felles `FilterPanel`-komponent, samt legger til enhetstest for default statusfilter.

**Changes:**
- Introduserer ny gjenbrukbar `FilterPanel`-komponent for ExpansionCard + CheckboxGroup + counts + localStorage-open-state.
- Oppdaterer `StatusFilter` og `HendelseFilter` til å bruke `FilterPanel` i stedet for duplisert JSX.
- Legger til test for `getDefaultStatusFilter`.
