### PR TITLE
Fikset tittel i innbygger flate enkeltplass + fikset feil type for tiltakskode i Zod

### DIFF
--- a/apps/innbyggers-flate/src/mocks/mockKodeverk.ts
+++ b/apps/innbyggers-flate/src/mocks/mockKodeverk.ts
@@ -1,7 +1,8 @@
-import { FlattKodeverk } from 'deltaker-flate-common'
+import { FlattKodeverk, Tiltakskode } from 'deltaker-flate-common'
 
 export const createMockFlatKodeverk = (): FlattKodeverk => {
   return {
+    tiltakskode: Tiltakskode.ENKELTPLASS_ARBEIDSMARKEDSOPPLAERING,
     tittel: 'Butikk- og salgsarbeid',
     valg: ['B - Personbil', 'C - Lastebil'],
     valgteKodeverkIder: [

--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.tsx
@@ -4,7 +4,6 @@ import {
   DeltakelseInnhold,
   UtkastHeader,
   hentGjennomforingNavnHosArrangorTekst,
-  hentTiltakNavnHosArrangorTekst,
   useDeferredFetch,
   VeilederSnakkeboble,
   formatDateFromString,
@@ -18,9 +17,11 @@ export const UtkastEnkeltplassPage = () => {
   const { deltaker, setDeltaker, setShowSuccessMessage } = useDeltakerContext()
   const deltakerliste = deltaker.deltakerliste
 
-  const tiltakOgStedTekst = hentTiltakNavnHosArrangorTekst(
+  const tiltakNavnHosArrangorTekst = hentGjennomforingNavnHosArrangorTekst(
     deltakerliste.tiltakskode,
-    deltakerliste.arrangorNavn
+    deltakerliste.deltakerlisteNavn,
+    deltakerliste.arrangorNavn,
+    deltakerliste.kodeverk?.tittel
   )
 
   const { deltakerId } = useParams()
@@ -44,7 +45,7 @@ export const UtkastEnkeltplassPage = () => {
   return (
     <div className="flex flex-col items-start mb-8">
       <Heading level="1" size="xlarge">
-        {tiltakOgStedTekst}
+        {tiltakNavnHosArrangorTekst}
       </Heading>
       <Heading
         level="2"

--- a/apps/innbyggers-flate/src/pages/UtkastPage.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastPage.tsx
@@ -33,12 +33,14 @@ export const UtkastPage = () => {
   const erUtkastTilSoknad = kreverGodkjenningForPamelding(
     deltakerliste.pameldingstype
   )
+
   const arrangorNavn = deltakerliste.arrangorNavn
   const navnHosArrangorTekst = hentTiltakEllerGjennomforingNavnHosArrangorTekst(
     deltakerliste.tiltakskode,
     deltakerliste.deltakerlisteNavn,
     arrangorNavn
   )
+
   const tiltakOgStedTekst = hentTiltakNavnHosArrangorTekst(
     deltakerliste.tiltakskode,
     deltakerliste.arrangorNavn

--- a/apps/nav-veileders-flate/src/api/data/kodeverk.ts
+++ b/apps/nav-veileders-flate/src/api/data/kodeverk.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { sertifiseringValgSchema } from 'deltaker-flate-common'
+import { sertifiseringValgSchema, Tiltakskode } from 'deltaker-flate-common'
 
 // Re-eksporter det flate kodeverket fra fellespakken slik at eksisterende
 // imports fra denne fila fortsatt fungerer (FlattKodeverk, utflatetKodeverkSchema).
@@ -106,7 +106,7 @@ export type KodeverkContainer =
   | KodeverkVerdigruppeSok
 
 export const kodeverkResponseSchema = z.object({
-  tiltakskode: z.string(),
+  tiltakskode: z.enum(Tiltakskode),
   alternativer: z.array(
     z.union([
       kodeverkUtdanningGruppeSchema,

--- a/apps/nav-veileders-flate/src/components/pamelding/PameldingHeader.test.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/PameldingHeader.test.tsx
@@ -42,6 +42,8 @@ describe('PameldingHeader - FOV heading', () => {
         deltakerliste={lagDeltakerliste()}
         vedtaksinformasjon={null}
         kodeverk={{
+          tiltakskode:
+            Tiltakskode.NORSKOPPLAERING_GRUNNLEGGENDE_FERDIGHETER_FOV,
           tittel: 'Norskopplæring B1',
           valg: [],
           valgteKodeverkIder: [],
@@ -99,6 +101,7 @@ describe('PameldingHeader - FOV heading', () => {
         })}
         vedtaksinformasjon={null}
         kodeverk={{
+          tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
           tittel: 'Bransje: Bygg',
           valg: ['Bygg'],
           valgteKodeverkIder: [],
@@ -135,6 +138,7 @@ describe('DeltakelseInnhold', () => {
           tiltakskode={Tiltakskode.ARBEIDSMARKEDSOPPLAERING}
           deltakelsesinnhold={null}
           kodeverk={{
+            tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
             tittel: 'Bransje',
             valg: ['IT'],
             valgteKodeverkIder: [],
@@ -152,6 +156,7 @@ describe('DeltakelseInnhold', () => {
           tiltakskode={Tiltakskode.ARBEIDSMARKEDSOPPLAERING}
           deltakelsesinnhold={null}
           kodeverk={{
+            tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
             tittel: null,
             valg: [],
             valgteKodeverkIder: [],

--- a/apps/nav-veileders-flate/src/components/pamelding/enkeltplass/tests/KodeverkValg.test.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/enkeltplass/tests/KodeverkValg.test.tsx
@@ -10,6 +10,7 @@ import {
   KodeverkResponse,
   Seleksjonstype
 } from '../../../../api/data/kodeverk'
+import { Tiltakskode } from 'deltaker-flate-common'
 
 const bransjeVerdigruppe = {
   type: KodeverkAlternativType.VERDIGRUPPE as const,
@@ -47,7 +48,7 @@ describe('KodeverkValg', () => {
 
   it('rendrer ikke når alternativer er tom', () => {
     const kodeverk: KodeverkResponse = {
-      tiltakskode: 'ARBEIDSMARKEDSOPPLAERING',
+      tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
       alternativer: [],
       sertifiseringValg: []
     }
@@ -59,7 +60,7 @@ describe('KodeverkValg', () => {
 
   it('rendrer combobox for en Verdigruppe', () => {
     const kodeverk: KodeverkResponse = {
-      tiltakskode: 'ARBEIDSMARKEDSOPPLAERING',
+      tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
       alternativer: [bransjeVerdigruppe],
       sertifiseringValg: []
     }
@@ -69,7 +70,7 @@ describe('KodeverkValg', () => {
 
   it('viser forhåndsvalgte verdier fra valgt: true', () => {
     const kodeverk: KodeverkResponse = {
-      tiltakskode: 'ARBEIDSMARKEDSOPPLAERING',
+      tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
       alternativer: [
         {
           ...bransjeVerdigruppe,
@@ -92,7 +93,7 @@ describe('KodeverkValg', () => {
     it('beholder valg fra begge verdigrupper i form state', async () => {
       const user = userEvent.setup()
       const kodeverk: KodeverkResponse = {
-        tiltakskode: 'ARBEIDSMARKEDSOPPLAERING',
+        tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         alternativer: [bransjeVerdigruppe, forerkortVerdigruppe],
         sertifiseringValg: []
       }
@@ -126,7 +127,7 @@ describe('KodeverkValg', () => {
     it('endring i én verdigruppe overskriver ikke den andre', async () => {
       const user = userEvent.setup()
       const kodeverk: KodeverkResponse = {
-        tiltakskode: 'ARBEIDSMARKEDSOPPLAERING',
+        tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         alternativer: [bransjeVerdigruppe, forerkortVerdigruppe],
         sertifiseringValg: []
       }
@@ -171,7 +172,7 @@ describe('KodeverkValg', () => {
     it('enkeltvalg erstatter forrige valg i samme verdigruppe', async () => {
       const user = userEvent.setup()
       const kodeverk: KodeverkResponse = {
-        tiltakskode: 'ARBEIDSMARKEDSOPPLAERING',
+        tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         alternativer: [bransjeVerdigruppe],
         sertifiseringValg: []
       }
@@ -209,7 +210,7 @@ describe('KodeverkValg', () => {
 
   describe('UtdanningGruppe med lærefag', () => {
     const gruppeKodeverk: KodeverkResponse = {
-      tiltakskode: 'FAG_OG_YRKESOPPLAERING',
+      tiltakskode: Tiltakskode.ENKELTPLASS_FAG_OG_YRKESOPPLAERING,
       sertifiseringValg: [],
       alternativer: [
         {

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
@@ -72,6 +72,7 @@ const renderWithDeltaker = (deltaker: DeltakerResponse) =>
 describe('UtkastDeltakerEnkeltplass - VeilederSnakkeboble', () => {
   it('bruker kodeverk.tittel i snakkeboblen når tilgjengelig', () => {
     const deltaker = lagDeltaker({
+      tiltakskode: Tiltakskode.NORSKOPPLAERING_GRUNNLEGGENDE_FERDIGHETER_FOV,
       tittel: 'Norskopplæring B1',
       valg: ['Muntlig'],
       valgteKodeverkIder: [],
@@ -101,6 +102,7 @@ describe('UtkastDeltakerEnkeltplass - VeilederSnakkeboble', () => {
 
   it('faller tilbake til deltakerlisteNavn når kodeverk.tittel er null', () => {
     const deltaker = lagDeltaker({
+      tiltakskode: Tiltakskode.NORSKOPPLAERING_GRUNNLEGGENDE_FERDIGHETER_FOV,
       tittel: null,
       valg: ['Muntlig'],
       valgteKodeverkIder: [],

--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -113,7 +113,7 @@ export class MockHandler {
         pameldingstype: Pameldingstype.TRENGER_GODKJENNING,
         oppmoteSted:
           'Fjordgata 7b, 00 Stedet. Inngangsdør rundt svingen. Oppmøte kl. 09:00. ',
-        kodeverk: createMockFlatKodeverk()
+        kodeverk: createMockFlatKodeverk(this.tiltakskode)
       },
       status: {
         id: '85a05446-7211-4bbc-88ad-970f7ef9fb04',
@@ -453,7 +453,7 @@ export class MockHandler {
     if (oppdatertPamelding) {
       oppdatertPamelding.deltakerliste.tiltakskode = tiltakskode
       oppdatertPamelding.deltakerliste.kodeverk = erNyEnkeltplass
-        ? createMockFlatKodeverk()
+        ? createMockFlatKodeverk(this.tiltakskode)
         : null
       oppdatertPamelding.adresseDelesMedArrangor =
         delesAdresseMedArrangor(tiltakskode)

--- a/apps/nav-veileders-flate/src/mocks/mockKodeverk.ts
+++ b/apps/nav-veileders-flate/src/mocks/mockKodeverk.ts
@@ -9,8 +9,11 @@ import {
   VerdigruppeSokKilde
 } from '../api/data/kodeverk'
 
-export const createMockFlatKodeverk = (): FlattKodeverk => {
+export const createMockFlatKodeverk = (
+  tiltakskode: Tiltakskode
+): FlattKodeverk => {
   return {
+    tiltakskode: tiltakskode,
     tittel: 'Butikk- og salgsarbeid',
     valg: ['B - Personbil', 'C - Lastebil'],
     valgteKodeverkIder: [

--- a/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.test.ts
+++ b/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.test.ts
@@ -36,6 +36,7 @@ describe('generateEnkeltplassPameldingRequest', () => {
   it('returnerer tomme lister når det flate kodeverket ikke har valgte verdier', () => {
     const request = generateEnkeltplassPameldingRequest(
       lagDeltaker({
+        tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         tittel: 'Bransje',
         valg: [],
         valgteKodeverkIder: [],
@@ -49,6 +50,7 @@ describe('generateEnkeltplassPameldingRequest', () => {
   it('returnerer valgteKodeverkIder fra det flate kodeverket', () => {
     const request = generateEnkeltplassPameldingRequest(
       lagDeltaker({
+        tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         tittel: 'Bransje, Lærefag',
         valg: ['Bygg', 'Tømrer', 'Rørlegger'],
         valgteKodeverkIder: [
@@ -70,6 +72,7 @@ describe('generateEnkeltplassPameldingRequest', () => {
   it('returnerer valgteSertifiseringer fra det flate kodeverket', () => {
     const request = generateEnkeltplassPameldingRequest(
       lagDeltaker({
+        tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         tittel: null,
         valg: [],
         valgteKodeverkIder: [],

--- a/packages/deltaker-flate-common/model/kodeverk.ts
+++ b/packages/deltaker-flate-common/model/kodeverk.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { Tiltakskode } from './deltaker.ts'
 
 /**
  * Skjema for valgte sertifiseringer (Janzz-ID + visningsnavn).
@@ -17,6 +18,7 @@ export const sertifiseringValgSchema = z.array(
  * ikke hele hierarkiet av valg.
  */
 export const utflatetKodeverkSchema = z.object({
+  tiltakskode: z.enum(Tiltakskode),
   tittel: z.string().nullable(),
   valg: z.array(z.string()),
   valgteKodeverkIder: z.array(z.uuid()),


### PR DESCRIPTION
## Description
Oppdaterer håndtering av kodeverk i frontend ved å (1) la innbygger-flaten vise riktig tittel for enkeltplass (spesielt FOV når `kodeverk.tittel` finnes), og (2) stramme inn/rette Zod-typing av `tiltakskode` ved å bruke `Tiltakskode`-enum og inkludere `tiltakskode` i flatt kodeverk.

**Changes:**
- La `UtkastEnkeltplassPage` bruke `hentGjennomforingNavnHosArrangorTekst(..., kodeverk?.tittel)` slik at FOV kan vise `kodeverk.tittel` i heading.
- Oppdaterte Zod-skjemaer til å validere `tiltakskode` mot `Tiltakskode` (og la `FlattKodeverk` inkludere `tiltakskode`).
- Justerte mocks og tester til å bruke `Tiltakskode` og/eller sette `tiltakskode` i kodeverk-objekter.
