### PR TITLE
Date-parsing fixes

### DIFF
--- a/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.test.ts
+++ b/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.test.ts
@@ -27,6 +27,30 @@ const lagDeltaker = (
   }) as unknown as DeltakerResponse
 
 describe('generateEnkeltplassPameldingRequest', () => {
+  it('beholder gyldige ISO-datoer fra backend i request', () => {
+    const request = generateEnkeltplassPameldingRequest({
+      ...lagDeltaker(),
+      startdato: new Date(2026, 4, 6),
+      sluttdato: new Date(2026, 4, 12)
+    })
+
+    expect(request.startdato).toBe('2026-05-06')
+    expect(request.sluttdato).toBe('2026-05-12')
+  })
+
+  it('setter tom streng for ugyldige datoer i stedet for "Invalid Date"', () => {
+    const request = generateEnkeltplassPameldingRequest({
+      ...lagDeltaker(),
+      startdato: new Date('ugyldig-dato'),
+      sluttdato: new Date('fortsatt-ugyldig-dato')
+    })
+
+    expect(request.startdato).toBe('')
+    expect(request.sluttdato).toBe('')
+    expect(request.startdato).not.toBe('Invalid Date')
+    expect(request.sluttdato).not.toBe('Invalid Date')
+  })
+
   it('returnerer undefined kodeverkValg og sertifiseringValg når deltaker mangler kodeverk', () => {
     const request = generateEnkeltplassPameldingRequest(lagDeltaker(null))
     expect(request.kodeverkValg).toBeUndefined()

--- a/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.ts
+++ b/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.ts
@@ -44,12 +44,15 @@ export const formToEnkeltplassRequest = (
 export const generateEnkeltplassPameldingRequest = (
   deltaker: DeltakerResponse
 ): EnkeltplassPameldingRequest => {
-  const startdato = deltaker.startdato
-    ? dayjs(deltaker.startdato, DATE_FORMAT, true)?.toDate()
-    : null
-  const sluttdato = deltaker.sluttdato
-    ? dayjs(deltaker.sluttdato, DATE_FORMAT, true)?.toDate()
-    : null
+  const parsedStartdato = deltaker.startdato ? dayjs(deltaker.startdato) : null
+  const startdato = parsedStartdato?.isValid()
+    ? formatDateToDtoStr(parsedStartdato.toDate())
+    : ''
+
+  const parsedSluttdato = deltaker.sluttdato ? dayjs(deltaker.sluttdato) : null
+  const sluttdato = parsedSluttdato?.isValid()
+    ? formatDateToDtoStr(parsedSluttdato.toDate())
+    : ''
 
   return {
     beskrivelse:
@@ -57,8 +60,8 @@ export const generateEnkeltplassPameldingRequest = (
         (i) => i.innholdskode === INNHOLD_TYPE_ANNET
       )?.beskrivelse || '',
     prisinformasjon: deltaker.prisinformasjon || '',
-    startdato: startdato ? formatDateToDtoStr(startdato) : '',
-    sluttdato: sluttdato ? formatDateToDtoStr(sluttdato) : '',
+    startdato,
+    sluttdato,
     arrangorUnderenhet:
       deltaker.deltakerliste.arrangor?.organisasjonsnummer || '',
     kodeverkValg: deltaker.deltakerliste.kodeverk?.valgteKodeverkIder,

--- a/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.ts
+++ b/apps/nav-veileders-flate/src/utils/pamelding-enkeltplass.ts
@@ -7,7 +7,7 @@ import {
   DATE_FORMAT,
   PameldingEnkeltplassFormValues
 } from '../model/PameldingEnkeltplassFormValues'
-import { formatDateToDtoStr } from './utils'
+import { dateToIsoString, formatDateToDtoStr } from './utils'
 
 const formToEnkeltplassData = (data: PameldingEnkeltplassFormValues) => {
   const startdatoParsed = dayjs(data.startdato, DATE_FORMAT, true)
@@ -44,24 +44,14 @@ export const formToEnkeltplassRequest = (
 export const generateEnkeltplassPameldingRequest = (
   deltaker: DeltakerResponse
 ): EnkeltplassPameldingRequest => {
-  const parsedStartdato = deltaker.startdato ? dayjs(deltaker.startdato) : null
-  const startdato = parsedStartdato?.isValid()
-    ? formatDateToDtoStr(parsedStartdato.toDate())
-    : ''
-
-  const parsedSluttdato = deltaker.sluttdato ? dayjs(deltaker.sluttdato) : null
-  const sluttdato = parsedSluttdato?.isValid()
-    ? formatDateToDtoStr(parsedSluttdato.toDate())
-    : ''
-
   return {
     beskrivelse:
       deltaker.deltakelsesinnhold?.innhold.find(
         (i) => i.innholdskode === INNHOLD_TYPE_ANNET
       )?.beskrivelse || '',
     prisinformasjon: deltaker.prisinformasjon || '',
-    startdato,
-    sluttdato,
+    startdato: dateToIsoString(deltaker.startdato),
+    sluttdato: dateToIsoString(deltaker.sluttdato),
     arrangorUnderenhet:
       deltaker.deltakerliste.arrangor?.organisasjonsnummer || '',
     kodeverkValg: deltaker.deltakerliste.kodeverk?.valgteKodeverkIder,

--- a/apps/nav-veileders-flate/src/utils/utils.test.ts
+++ b/apps/nav-veileders-flate/src/utils/utils.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   erGyldigProsent,
   isValidFloatInRange,
-  erGyldigDagerPerUke
+  erGyldigDagerPerUke,
+  dateToIsoString
 } from './utils'
 import { EMDASH, formatDateFromString } from 'deltaker-flate-common'
 
@@ -87,4 +88,15 @@ describe('formatDateFromString', () => {
     expect(formatDateFromString('aa')).toBe(EMDASH))
   it('Formates null date to —', () =>
     expect(formatDateFromString('aa')).toBe(EMDASH))
+})
+
+describe('dateToIsoString', () => {
+  it('returnerer ISO dato for gyldig Date', () =>
+    expect(dateToIsoString(new Date(2026, 4, 6))).toBe('2026-05-06'))
+
+  it('returnerer tom streng for null', () =>
+    expect(dateToIsoString(null)).toBe(''))
+
+  it('returnerer tom streng for ugyldig Date', () =>
+    expect(dateToIsoString(new Date('ugyldig-dato'))).toBe(''))
 })

--- a/apps/nav-veileders-flate/src/utils/utils.ts
+++ b/apps/nav-veileders-flate/src/utils/utils.ts
@@ -14,6 +14,11 @@ export const formatDateToInputStr = (date: Date): string => {
   return dayjs(date).format('DD.MM.YYYY')
 }
 
+export const dateToIsoString = (date: Date | null): string => {
+  const parsedDate = date ? dayjs(date) : null
+  return parsedDate?.isValid() ? formatDateToDtoStr(parsedDate.toDate()) : ''
+}
+
 /**
  * Formaterer date til string: DD.MM.YYYY
  * @param date


### PR DESCRIPTION
## Description
`DeltakerResponse.startdato`/`sluttdato` are parsed to `Date | null` when read from API, but the direct enrollment fallback path treated them as `DD.MM.YYYY` strings. This caused valid dates to be dropped when building `EnkeltplassPameldingRequest`.

- **Data flow correction**
  - Updated `generateEnkeltplassPameldingRequest` to format parsed `Date` values directly instead of strict re-parsing with `DATE_FORMAT`.
- **Regression coverage**
  - Added a focused unit test that asserts API dates are preserved and mapped to DTO format (`YYYY-MM-DD`) in the generated request.

```ts
startdato: deltaker.startdato ? formatDateToDtoStr(deltaker.startdato) : '',
sluttdato: deltaker.sluttdato ? formatDateToDtoStr(deltaker.sluttdato) : '',
```
