### PR TITLE
Retter feil som åpner for at man kan reaktivere deltakelse på en avsluttet deltakerliste

### DIFF
--- a/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
+++ b/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import {
+  DeltakerlisteStatus,
   DeltakerStatusType,
   EndreDeltakelseType,
   harBakgrunnsinfo,
@@ -192,7 +193,11 @@ export const getEndreDeltakelsesValg = (pamelding: DeltakerResponse) => {
   if (skalViseEndreAvslutning(pamelding) && !deltakelseErLaast) {
     valg.push(EndreDeltakelseType.ENDRE_AVSLUTNING)
   }
-  if (ikkeAktuell(pamelding) && !deltakelseErLaast) {
+  if (
+    ikkeAktuell(pamelding) &&
+    !deltakelseErLaast &&
+    pamelding.deltakerliste.status === DeltakerlisteStatus.GJENNOMFORES
+  ) {
     valg.push(EndreDeltakelseType.REAKTIVER_DELTAKELSE)
   }
 


### PR DESCRIPTION
## Description

Retter feil som åpner for at man kan reaktivere deltakelse på en avsluttet deltakerliste

## Trello card
https://trello.com/c/ZKLO9i80/2764-fjerne-endringsvalget-reaktivering-dersom-gjennomf%C3%B8ringen-er-avsluttet

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other: ****\_\_****

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have linked this PR in related Trello card.
