### PR TITLE
Fiks visning av deltakelsesmengde enkeltplass

### DIFF
--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
@@ -130,4 +130,15 @@ describe('UtkastEnkeltplassPage - Deltakelsesmengde', () => {
 
     expect(screen.getByText('1 dag i uka')).toBeInTheDocument()
   })
+
+  it('viser overskrift uten dagtekst når dagerPerUke er 0', () => {
+    const deltaker = lagDeltaker({
+      dagerPerUke: 0
+    })
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.queryByText(/dag(er)? i uka/)).not.toBeInTheDocument()
+  })
 })

--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
@@ -131,14 +131,14 @@ describe('UtkastEnkeltplassPage - Deltakelsesmengde', () => {
     expect(screen.getByText('1 dag i uka')).toBeInTheDocument()
   })
 
-  it('viser overskrift uten dagtekst når dagerPerUke er 0', () => {
+  it('skjuler deltakelsesmengde når dagerPerUke er 0', () => {
     const deltaker = lagDeltaker({
       dagerPerUke: 0
     })
 
     renderWithDeltaker(deltaker)
 
-    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.queryByText('Deltakelsesmengde')).not.toBeInTheDocument()
     expect(screen.queryByText(/dag(er)? i uka/)).not.toBeInTheDocument()
   })
 })

--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
@@ -1,0 +1,133 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DeltakerStatusType, Tiltakskode } from 'deltaker-flate-common'
+import { UtkastEnkeltplassPage } from './UtkastEnkeltplassPage'
+import { DeltakerContext } from '../DeltakerContext'
+import { DeltakerResponse } from '../api/data/deltaker'
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
+dayjs.extend(duration)
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ deltakerId: 'deltaker-123' })
+}))
+
+const lagDeltaker = (
+  overrides: Partial<DeltakerResponse> = {}
+): DeltakerResponse =>
+  ({
+    deltakerId: '1',
+    fornavn: 'Ola',
+    mellomnavn: null,
+    etternavn: 'Nordmann',
+    deltakerliste: {
+      deltakerlisteId: '1',
+      deltakerlisteNavn: 'Arbeidsmarkedsopplæring',
+      tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
+      arrangorNavn: 'Test AS',
+      arrangor: { navn: 'Test AS', organisasjonsnummer: '999888777' },
+      erEnkeltplass: true,
+      oppstartstype: null,
+      startdato: null,
+      sluttdato: null,
+      status: null,
+      tilgjengeligInnhold: { ledetekst: null, innhold: [] },
+      oppmoteSted: null,
+      pameldingstype: 'TRENGER_GODKJENNING',
+      opplaringKategoriseringValg: null,
+      prisinformasjon: null
+    },
+    status: {
+      id: '1',
+      type: DeltakerStatusType.UTKAST_TIL_PAMELDING,
+      aarsak: null,
+      gyldigFra: new Date(),
+      gyldigTil: null,
+      opprettet: new Date()
+    },
+    startdato: '2025-04-10',
+    sluttdato: '2025-10-09',
+    deltakelsesinnhold: { ledetekst: null, innhold: [] },
+    vedtaksinformasjon: null,
+    deltakelsesprosent: null,
+    dagerPerUke: null,
+    kanEndres: true,
+    digitalBruker: true,
+    maxVarighet: dayjs.duration(12, 'month').asMilliseconds(),
+    softMaxVarighet: dayjs.duration(12, 'month').asMilliseconds(),
+    forslag: [],
+    importertFraArena: null,
+    harAdresse: false,
+    adresseDelesMedArrangor: false,
+    deltakelsesmengder: {
+      sisteDeltakelsesmengde: null,
+      nesteDeltakelsesmengde: null
+    },
+    erUnderOppfolging: true,
+    erManueltDeltMedArrangor: false,
+    ...overrides
+  }) as unknown as DeltakerResponse
+
+const renderWithDeltaker = (deltaker: DeltakerResponse) =>
+  render(
+    <DeltakerContext.Provider
+      value={{
+        deltaker,
+        setDeltaker: vi.fn(),
+        showSuccessMessage: false,
+        setShowSuccessMessage: vi.fn()
+      }}
+    >
+      <UtkastEnkeltplassPage />
+    </DeltakerContext.Provider>
+  )
+
+describe('UtkastEnkeltplassPage - Deltakelsesmengde', () => {
+  it('viser deltakelsesmengde når arbeidsmarkedsopplæring og dagerPerUke er satt', () => {
+    const deltaker = lagDeltaker({
+      dagerPerUke: 3
+    })
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.getByText('3 dager i uka')).toBeInTheDocument()
+  })
+
+  it('viser deltakelsesmengde når enkeltplass og dagerPerUke er satt for andre tiltakskoder', () => {
+    const deltaker = lagDeltaker({
+      deltakerliste: {
+        ...lagDeltaker().deltakerliste,
+        tiltakskode: Tiltakskode.VARIG_TILRETTELAGT_ARBEID_SKJERMET
+      },
+      dagerPerUke: 4
+    })
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.getByText('4 dager i uka')).toBeInTheDocument()
+  })
+
+  it('skjuler deltakelsesmengde når dagerPerUke er null', () => {
+    const deltaker = lagDeltaker({
+      dagerPerUke: null
+    })
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.queryByText('Deltakelsesmengde')).not.toBeInTheDocument()
+  })
+
+  it('viser 1 dag i uka når dagerPerUke er 1', () => {
+    const deltaker = lagDeltaker({
+      dagerPerUke: 1
+    })
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('1 dag i uka')).toBeInTheDocument()
+  })
+})

--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.tsx
@@ -8,7 +8,9 @@ import {
   formatDateFromString,
   hentTiltakHosArrangorIngressTekst,
   hentTiltakHosArrangorTittel,
-  useDeferredFetch
+  useDeferredFetch,
+  harDeltakelsesmengde,
+  deltakerprosentText
 } from 'deltaker-flate-common'
 import { useParams } from 'react-router-dom'
 import { useDeltakerContext } from '../DeltakerContext'
@@ -90,6 +92,25 @@ export const UtkastEnkeltplassPage = () => {
           </Heading>
         }
       />
+
+      {harDeltakelsesmengde({
+        tiltakskode: deltaker.deltakerliste.tiltakskode,
+        erEnkeltplass: true
+      }) &&
+        deltaker.dagerPerUke != null && (
+          <div className="mt-4">
+            <Heading level="3" size="small">
+              Deltakelsesmengde
+            </Heading>
+            <BodyLong size="small" className="mt-2">
+              {deltakerprosentText(
+                deltaker.deltakelsesprosent,
+                deltaker.dagerPerUke,
+                true
+              )}
+            </BodyLong>
+          </div>
+        )}
 
       <PrisOgBetaling
         prisinformasjon={deltaker.deltakerliste.prisinformasjon}

--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.tsx
@@ -19,6 +19,11 @@ import { godkjennUtkast } from '../api/api'
 export const UtkastEnkeltplassPage = () => {
   const { deltaker, setDeltaker, setShowSuccessMessage } = useDeltakerContext()
   const deltakerliste = deltaker.deltakerliste
+  const deltakelsesmengdeText = deltakerprosentText(
+    deltaker.deltakelsesprosent,
+    deltaker.dagerPerUke,
+    true
+  )
 
   const tiltakNavnHosArrangorTekst = hentTiltakHosArrangorTittel(
     deltakerliste.tiltakskode,
@@ -97,17 +102,13 @@ export const UtkastEnkeltplassPage = () => {
         tiltakskode: deltaker.deltakerliste.tiltakskode,
         erEnkeltplass: true
       }) &&
-        deltaker.dagerPerUke != null && (
+        deltakelsesmengdeText && (
           <div className="mt-4">
             <Heading level="3" size="small">
               Deltakelsesmengde
             </Heading>
             <BodyLong size="small" className="mt-2">
-              {deltakerprosentText(
-                deltaker.deltakelsesprosent,
-                deltaker.dagerPerUke,
-                true
-              )}
+              {deltakelsesmengdeText}
             </BodyLong>
           </div>
         )}

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
@@ -121,3 +121,53 @@ describe('UtkastDeltakerEnkeltplass - VeilederSnakkeboble', () => {
     ).toBeInTheDocument()
   })
 })
+
+describe('UtkastDeltakerEnkeltplass - Deltakelsesmengde', () => {
+  it('viser deltakelsesmengde når dagerPerUke er satt', () => {
+    const deltaker = lagDeltaker()
+    deltaker.dagerPerUke = 3
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.getByText('3 dager i uka')).toBeInTheDocument()
+  })
+
+  it('skjuler deltakelsesmengde når dagerPerUke er null', () => {
+    const deltaker = lagDeltaker()
+    deltaker.dagerPerUke = null
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.queryByText('Deltakelsesmengde')).not.toBeInTheDocument()
+  })
+
+  it('viser 1 dag i uka når dagerPerUke er 1', () => {
+    const deltaker = lagDeltaker()
+    deltaker.dagerPerUke = 1
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('1 dag i uka')).toBeInTheDocument()
+  })
+
+  it('viser korrekt antall dager når dagerPerUke er 5', () => {
+    const deltaker = lagDeltaker()
+    deltaker.dagerPerUke = 5
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('5 dager i uka')).toBeInTheDocument()
+  })
+
+  it('viser deltakelsesmengde for arbeidsmarkedsopplæring', () => {
+    const deltaker = lagDeltaker()
+    deltaker.deltakerliste.tiltakskode = Tiltakskode.ARBEIDSMARKEDSOPPLAERING
+    deltaker.dagerPerUke = 4
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.getByText('4 dager i uka')).toBeInTheDocument()
+  })
+})

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
@@ -171,13 +171,13 @@ describe('UtkastDeltakerEnkeltplass - Deltakelsesmengde', () => {
     expect(screen.getByText('4 dager i uka')).toBeInTheDocument()
   })
 
-  it('viser overskrift uten dagtekst når dagerPerUke er 0', () => {
+  it('skjuler deltakelsesmengde når dagerPerUke er 0', () => {
     const deltaker = lagDeltaker()
     deltaker.dagerPerUke = 0
 
     renderWithDeltaker(deltaker)
 
-    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.queryByText('Deltakelsesmengde')).not.toBeInTheDocument()
     expect(screen.queryByText(/dag(er)? i uka/)).not.toBeInTheDocument()
   })
 })

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.test.tsx
@@ -170,4 +170,14 @@ describe('UtkastDeltakerEnkeltplass - Deltakelsesmengde', () => {
     expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
     expect(screen.getByText('4 dager i uka')).toBeInTheDocument()
   })
+
+  it('viser overskrift uten dagtekst når dagerPerUke er 0', () => {
+    const deltaker = lagDeltaker()
+    deltaker.dagerPerUke = 0
+
+    renderWithDeltaker(deltaker)
+
+    expect(screen.getByText('Deltakelsesmengde')).toBeInTheDocument()
+    expect(screen.queryByText(/dag(er)? i uka/)).not.toBeInTheDocument()
+  })
 })

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.tsx
@@ -13,6 +13,11 @@ import { useDeltakerContext } from '../tiltak/DeltakerContext.tsx'
 export const UtkastDeltakerEnkeltplass = () => {
   const { deltaker } = useDeltakerContext()
   const tiltakskode = deltaker.deltakerliste.tiltakskode
+  const deltakelsesmengdeText = deltakerprosentText(
+    deltaker.deltakelsesprosent,
+    deltaker.dagerPerUke,
+    true
+  )
 
   return (
     <div className="flex flex-col gap-8">
@@ -47,17 +52,13 @@ export const UtkastDeltakerEnkeltplass = () => {
       />
 
       {harDeltakelsesmengde({ tiltakskode, erEnkeltplass: true }) &&
-        deltaker.dagerPerUke != null && (
+        deltakelsesmengdeText && (
           <div>
             <Heading level="3" size="small">
               Deltakelsesmengde
             </Heading>
             <BodyLong size="small" className="mt-2">
-              {deltakerprosentText(
-                deltaker.deltakelsesprosent,
-                deltaker.dagerPerUke,
-                true
-              )}
+              {deltakelsesmengdeText}
             </BodyLong>
           </div>
         )}

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltakerEnkeltplass.tsx
@@ -1,7 +1,9 @@
 import { BodyLong, Heading } from '@navikt/ds-react'
 import {
   DeltakelseInnhold,
+  deltakerprosentText,
   formatDate,
+  harDeltakelsesmengde,
   hentTiltakHosArrangorIngressTekst,
   PrisOgBetaling,
   VeilederSnakkeboble
@@ -43,6 +45,22 @@ export const UtkastDeltakerEnkeltplass = () => {
           </Heading>
         }
       />
+
+      {harDeltakelsesmengde({ tiltakskode, erEnkeltplass: true }) &&
+        deltaker.dagerPerUke != null && (
+          <div>
+            <Heading level="3" size="small">
+              Deltakelsesmengde
+            </Heading>
+            <BodyLong size="small" className="mt-2">
+              {deltakerprosentText(
+                deltaker.deltakelsesprosent,
+                deltaker.dagerPerUke,
+                true
+              )}
+            </BodyLong>
+          </div>
+        )}
 
       <PrisOgBetaling
         prisinformasjon={deltaker.deltakerliste.prisinformasjon}

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
@@ -38,7 +38,7 @@ describe('DeltakelsesmengdeInfo', () => {
       nesteDeltakelsesmengde: {
         deltakelsesprosent: 60,
         dagerPerUke: 3,
-        gyldigFra: '2025-08-01'
+        gyldigFra: '2025-08-01' as unknown as Date
       }
     })
     const text = extractText(result).join(' ')
@@ -62,17 +62,14 @@ describe('DeltakelsesmengdeInfo', () => {
     expect(text).not.toContain('Nåværende periode:')
   })
 
-  it('viser kun overskrift når dagerPerUke er 0 uten neste periode', () => {
+  it('returnerer null når dagerPerUke er 0 uten neste periode', () => {
     const result = DeltakelsesmengdeInfo({
       deltakelsesprosent: null,
       dagerPerUke: 0,
       erEnkeltplass: true,
       nesteDeltakelsesmengde: null
     })
-    const text = extractText(result).join(' ')
 
-    expect(text).toContain('Deltakelsesmengde')
-    expect(text).not.toContain('dag i uka')
-    expect(text).not.toContain('dager i uka')
+    expect(result).toBeNull()
   })
 })

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
@@ -1,0 +1,64 @@
+import { isValidElement, ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { DeltakelsesmengdeInfo } from './DeltakelsesmengdeInfo'
+
+const extractText = (node: ReactNode): string[] => {
+  if (node == null || typeof node === 'boolean') {
+    return []
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return [String(node)]
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap(extractText)
+  }
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return extractText(node.props.children)
+  }
+  return []
+}
+
+describe('DeltakelsesmengdeInfo', () => {
+  it('returnerer null når enkeltplass mangler nåværende og neste deltakelsesmengde', () => {
+    const result = DeltakelsesmengdeInfo({
+      deltakelsesprosent: null,
+      dagerPerUke: null,
+      erEnkeltplass: true,
+      nesteDeltakelsesmengde: null
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('viser "(ikke satt)" for nåværende periode når neste deltakelsesmengde finnes', () => {
+    const result = DeltakelsesmengdeInfo({
+      deltakelsesprosent: null,
+      dagerPerUke: null,
+      erEnkeltplass: true,
+      nesteDeltakelsesmengde: {
+        deltakelsesprosent: 60,
+        dagerPerUke: 3,
+        gyldigFra: '2025-08-01'
+      }
+    })
+    const text = extractText(result).join(' ')
+
+    expect(text).toContain('Nåværende periode:')
+    expect(text).toContain('(ikke satt)')
+    expect(text).toContain('3 dager i uka')
+  })
+
+  it('viser enkel periode når neste deltakelsesmengde mangler', () => {
+    const result = DeltakelsesmengdeInfo({
+      deltakelsesprosent: null,
+      dagerPerUke: 2,
+      erEnkeltplass: true,
+      nesteDeltakelsesmengde: null
+    })
+    const text = extractText(result).join(' ')
+
+    expect(text).toContain('Deltakelsesmengde')
+    expect(text).toContain('2 dager i uka')
+    expect(text).not.toContain('Nåværende periode:')
+  })
+})

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
@@ -61,4 +61,18 @@ describe('DeltakelsesmengdeInfo', () => {
     expect(text).toContain('2 dager i uka')
     expect(text).not.toContain('Nåværende periode:')
   })
+
+  it('viser kun overskrift når dagerPerUke er 0 uten neste periode', () => {
+    const result = DeltakelsesmengdeInfo({
+      deltakelsesprosent: null,
+      dagerPerUke: 0,
+      erEnkeltplass: true,
+      nesteDeltakelsesmengde: null
+    })
+    const text = extractText(result).join(' ')
+
+    expect(text).toContain('Deltakelsesmengde')
+    expect(text).not.toContain('dag i uka')
+    expect(text).not.toContain('dager i uka')
+  })
 })

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.test.tsx
@@ -38,7 +38,7 @@ describe('DeltakelsesmengdeInfo', () => {
       nesteDeltakelsesmengde: {
         deltakelsesprosent: 60,
         dagerPerUke: 3,
-        gyldigFra: '2025-08-01' as unknown as Date
+        gyldigFra: new Date('2025-08-01')
       }
     })
     const text = extractText(result).join(' ')

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.tsx
@@ -16,7 +16,13 @@ export function DeltakelsesmengdeInfo({
   erEnkeltplass,
   nesteDeltakelsesmengde
 }: Props) {
-  if (erEnkeltplass && dagerPerUke == null && nesteDeltakelsesmengde == null) {
+  const deltakelsesmengdeText = deltakerprosentText(
+    deltakelsesprosent,
+    dagerPerUke,
+    erEnkeltplass
+  )
+
+  if (!nesteDeltakelsesmengde && !deltakelsesmengdeText) {
     return null
   }
   return (
@@ -30,11 +36,7 @@ export function DeltakelsesmengdeInfo({
             Nåværende periode:
           </BodyShort>
           <BodyShort size="small">
-            {deltakerprosentText(
-              deltakelsesprosent,
-              dagerPerUke,
-              erEnkeltplass
-            ) || '(ikke satt)'}
+            {deltakelsesmengdeText || '(ikke satt)'}
           </BodyShort>
           <BodyShort size="small" className="mt-2">
             Neste periode (fom. {formatDate(nesteDeltakelsesmengde.gyldigFra)}
@@ -50,7 +52,7 @@ export function DeltakelsesmengdeInfo({
         </>
       ) : (
         <BodyShort size="small" className="mt-2">
-          {deltakerprosentText(deltakelsesprosent, dagerPerUke, erEnkeltplass)}
+          {deltakelsesmengdeText}
         </BodyShort>
       )}
     </>

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.tsx
@@ -16,7 +16,7 @@ export function DeltakelsesmengdeInfo({
   erEnkeltplass,
   nesteDeltakelsesmengde
 }: Props) {
-  if (erEnkeltplass && dagerPerUke == null) {
+  if (erEnkeltplass && dagerPerUke == null && nesteDeltakelsesmengde == null) {
     return null
   }
   return (

--- a/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.tsx
+++ b/packages/deltaker-flate-common/components/DeltakelsesmengdeInfo.tsx
@@ -34,7 +34,7 @@ export function DeltakelsesmengdeInfo({
               deltakelsesprosent,
               dagerPerUke,
               erEnkeltplass
-            )}
+            ) || '(ikke satt)'}
           </BodyShort>
           <BodyShort size="small" className="mt-2">
             Neste periode (fom. {formatDate(nesteDeltakelsesmengde.gyldigFra)}


### PR DESCRIPTION
Fikser smårusk:
* Visning av deltakelsemengde på utkast-siden i innbygger-flate og veileder-flate
* Vis fremtidige deltakelsesmengder i edge case der det ikke er noen nåværende deltakelsesmengde