### PR TITLE
Sentralisering av visningslogikk: erstatt bruk av deltakerliste.tiltakskode med deltakerliste.tiltakskodeResponse.kode

### DIFF
--- a/apps/innbyggers-flate/src/api/data/deltaker.ts
+++ b/apps/innbyggers-flate/src/api/data/deltaker.ts
@@ -9,7 +9,6 @@ import {
   pameldingStatusSchema,
   Pameldingstype,
   prisinformasjonSchema,
-  Tiltakskode,
   tiltakskodeResponseSchema,
   vedtaksinformasjonSchema,
   visningsnavnSchema
@@ -19,7 +18,6 @@ import { z } from 'zod'
 export const deltakerlisteSchema = z.object({
   deltakerlisteId: z.uuid(),
   deltakerlisteNavn: z.string(),
-  tiltakskode: z.enum(Tiltakskode),
   tiltakskodeResponse: tiltakskodeResponseSchema,
   arrangorNavn: z.string(),
   oppstartstype: z.enum(Oppstartstype).nullable(),

--- a/apps/innbyggers-flate/src/mocks/MockHandler.ts
+++ b/apps/innbyggers-flate/src/mocks/MockHandler.ts
@@ -54,7 +54,6 @@ export const createDeltaker = (
     deltakerliste: {
       deltakerlisteId: '450e0f37-c4bb-4611-ac66-f725e05bad3e',
       deltakerlisteNavn: 'Testliste',
-      tiltakskode,
       tiltakskodeResponse: {
         kode: tiltakskode,
         visningsnavn: mockVisningsnavn(tiltakskode)
@@ -177,7 +176,6 @@ export class MockHandler {
       tiltakskode === Tiltakskode.HOYERE_UTDANNING
 
     if (oppdatertDeltaker) {
-      oppdatertDeltaker.deltakerliste.tiltakskode = tiltakskode
       oppdatertDeltaker.deltakerliste.tiltakskodeResponse = {
         kode: tiltakskode,
         visningsnavn: mockVisningsnavn(tiltakskode)

--- a/apps/innbyggers-flate/src/pages/AvbruttUtkastPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/AvbruttUtkastPage.test.tsx
@@ -24,7 +24,10 @@ describe('AvbruttUtkastPage - Deltakelsesmengde', () => {
     ...stottetTiltakDeltaker,
     deltakerliste: {
       ...stottetTiltakDeltaker.deltakerliste,
-      tiltakskode: Tiltakskode.OPPFOLGING
+      tiltakskodeResponse: {
+        kode: Tiltakskode.OPPFOLGING,
+        visningsnavn: 'Oppfølging'
+      }
     }
   }
 

--- a/apps/innbyggers-flate/src/pages/AvbruttUtkastPage.tsx
+++ b/apps/innbyggers-flate/src/pages/AvbruttUtkastPage.tsx
@@ -47,7 +47,7 @@ export const AvbruttUtkastPage = () => {
       )}
 
       <DeltakelsesmengdeAvsnitt
-        tiltakskode={deltaker.deltakerliste.tiltakskode}
+        tiltakskode={deltaker.deltakerliste.tiltakskodeResponse.kode}
         erEnkeltplass={deltaker.deltakerliste.erEnkeltplass}
         deltakelsesprosent={deltaker.deltakelsesprosent}
         dagerPerUke={deltaker.dagerPerUke}

--- a/apps/innbyggers-flate/src/pages/DeltakerPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/DeltakerPage.test.tsx
@@ -28,7 +28,10 @@ describe('DeltakerPage - Deltakelsesmengde', () => {
     ...stottetTiltakDeltaker,
     deltakerliste: {
       ...stottetTiltakDeltaker.deltakerliste,
-      tiltakskode: Tiltakskode.OPPFOLGING
+      tiltakskodeResponse: {
+        kode: Tiltakskode.OPPFOLGING,
+        visningsnavn: 'Oppfølging'
+      }
     }
   }
 

--- a/apps/innbyggers-flate/src/pages/DeltakerPage.tsx
+++ b/apps/innbyggers-flate/src/pages/DeltakerPage.tsx
@@ -178,7 +178,7 @@ export const DeltakerPage = () => {
       />
 
       <DeltakelsesmengdeInfo
-        tiltakskode={deltaker.deltakerliste.tiltakskode}
+        tiltakskode={deltaker.deltakerliste.tiltakskodeResponse.kode}
         deltakelsesprosent={deltaker.deltakelsesprosent}
         dagerPerUke={deltaker.dagerPerUke}
         nesteDeltakelsesmengde={

--- a/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastEnkeltplassPage.test.tsx
@@ -25,7 +25,6 @@ const lagDeltaker = (
     deltakerliste: {
       deltakerlisteId: '1',
       deltakerlisteNavn: 'Arbeidsmarkedsopplæring',
-      tiltakskode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
       tiltakskodeResponse: {
         kode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
         visningsnavn: 'Arbeidsmarkedsopplæring'

--- a/apps/innbyggers-flate/src/pages/UtkastPage.test.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastPage.test.tsx
@@ -18,7 +18,10 @@ describe('UtkastPage - Deltakelsesmengde', () => {
     ...stottetTiltakDeltaker,
     deltakerliste: {
       ...stottetTiltakDeltaker.deltakerliste,
-      tiltakskode: Tiltakskode.OPPFOLGING
+      tiltakskodeResponse: {
+        kode: Tiltakskode.OPPFOLGING,
+        visningsnavn: 'Oppfølging'
+      }
     }
   }
 

--- a/apps/innbyggers-flate/src/pages/UtkastPage.tsx
+++ b/apps/innbyggers-flate/src/pages/UtkastPage.tsx
@@ -126,7 +126,7 @@ export const UtkastPage = () => {
       )}
 
       <DeltakelsesmengdeAvsnitt
-        tiltakskode={deltakerliste.tiltakskode}
+        tiltakskode={deltakerliste.tiltakskodeResponse.kode}
         erEnkeltplass={deltakerliste.erEnkeltplass}
         deltakelsesprosent={deltaker.deltakelsesprosent}
         dagerPerUke={deltaker.dagerPerUke}

--- a/apps/innbyggers-flate/src/pages/test-utils.tsx
+++ b/apps/innbyggers-flate/src/pages/test-utils.tsx
@@ -12,7 +12,6 @@ export const lagInnbyggerDeltaker = (
   const baseDeltakerliste = {
     deltakerlisteId: 'l1',
     deltakerlisteNavn: 'Tiltak',
-    tiltakskode: Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
     tiltakskodeResponse: {
       kode: Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
       visningsnavn: 'Arbeidsforberedende trening'
@@ -76,7 +75,7 @@ export const lagInnbyggerDeltaker = (
     erUnderOppfolging: true,
     erManueltDeltMedArrangor: false,
     ...rest
-  } as unknown as DeltakerResponse
+  } as DeltakerResponse
 }
 
 export const renderWithInnbyggerDeltakerContext = (

--- a/apps/nav-veileders-flate/src/api/data/deltaker.ts
+++ b/apps/nav-veileders-flate/src/api/data/deltaker.ts
@@ -9,7 +9,6 @@ import {
   pameldingStatusSchema,
   Pameldingstype,
   prisinformasjonSchema,
-  Tiltakskode,
   tiltakskodeResponseSchema,
   vedtaksinformasjonSchema,
   visningsnavnSchema
@@ -32,7 +31,6 @@ const tilgjengeligInnholdSchema = z.object({
 export const deltakerlisteSchema = z.object({
   deltakerlisteId: z.uuid(),
   deltakerlisteNavn: z.string(),
-  tiltakskode: z.enum(Tiltakskode),
   tiltakskodeResponse: tiltakskodeResponseSchema,
   arrangorNavn: z.string(),
   arrangor: z

--- a/apps/nav-veileders-flate/src/components/pamelding/PameldingHeader.test.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/PameldingHeader.test.tsx
@@ -16,7 +16,6 @@ const lagDeltakerliste = (
   ({
     deltakerlisteId: '1',
     deltakerlisteNavn: 'Norskopplæring, grunnleggende ferdigheter og FOV',
-    tiltakskode: Tiltakskode.NORSKOPPLAERING_GRUNNLEGGENDE_FERDIGHETER_FOV,
     tiltakskodeResponse: {
       kode: Tiltakskode.NORSKOPPLAERING_GRUNNLEGGENDE_FERDIGHETER_FOV,
       visningsnavn: 'Norskopplæring, grunnleggende ferdigheter og FOV'

--- a/apps/nav-veileders-flate/src/components/pamelding/enkeltplass/PameldingEnkeltplassForm.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/enkeltplass/PameldingEnkeltplassForm.tsx
@@ -21,7 +21,7 @@ import { Loader } from '@navikt/ds-react'
 import { DeltakerResponse } from '../../../api/data/deltaker.ts'
 import { KodeverkResponse } from '../../../api/data/kodeverk.ts'
 import { DeltakelsesmengdeValg } from './DeltakelsesmengdeValg.tsx'
-import { harDeltakelsesmengde } from 'deltaker-flate-common'
+import { harDeltakerlisteDeltakelsesmengde } from 'deltaker-flate-common'
 
 interface Props {
   className?: string
@@ -107,7 +107,7 @@ const PameldingEnkeltplassFormInner = ({
         />
 
         <ArrangorValg />
-        {harDeltakelsesmengde(deltaker.deltakerliste) && (
+        {harDeltakerlisteDeltakelsesmengde(deltaker.deltakerliste) && (
           <DeltakelsesmengdeValg />
         )}
         <PrisOgBetaling />

--- a/apps/nav-veileders-flate/src/components/pamelding/enkeltplass/tests/test-utils.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/enkeltplass/tests/test-utils.tsx
@@ -22,7 +22,6 @@ export const createDeltaker = (
     deltakerliste: {
       deltakerlisteId: '1',
       deltakerlisteNavn: 'Test',
-      tiltakskode: Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
       tiltakskodeResponse: {
         kode: Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
         visningsnavn: 'Arbeidsmarkedsopplæring'

--- a/apps/nav-veileders-flate/src/components/pamelding/standard/PameldingForm.tsx
+++ b/apps/nav-veileders-flate/src/components/pamelding/standard/PameldingForm.tsx
@@ -4,7 +4,7 @@ import {
   erOpplaringstiltak,
   fjernUgyldigeTegn,
   harBakgrunnsinfo,
-  harDeltakelsesmengde,
+  harDeltakerlisteDeltakelsesmengde,
   harLopendeOppstart,
   OmKurset,
   Oppmotested,
@@ -116,7 +116,7 @@ export const PameldingForm = ({ className, focusOnOpen }: Props) => {
             </section>
           )}
 
-          {harDeltakelsesmengde(deltaker.deltakerliste) && (
+          {harDeltakerlisteDeltakelsesmengde(deltaker.deltakerliste) && (
             <div>
               <Heading size="medium" level="3" className="mb-4">
                 Deltakelsesmengde

--- a/apps/nav-veileders-flate/src/components/test-utils/deltaker-context-test-utils.tsx
+++ b/apps/nav-veileders-flate/src/components/test-utils/deltaker-context-test-utils.tsx
@@ -12,7 +12,6 @@ export const lagDeltaker = (
   const baseDeltakerliste = {
     deltakerlisteId: 'l1',
     deltakerlisteNavn: 'Tiltak',
-    tiltakskode: Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
     tiltakskodeResponse: {
       kode: Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
       visningsnavn: 'Arbeidsforberedende trening'

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.test.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.test.tsx
@@ -24,7 +24,10 @@ describe('DeltakerInfo - Deltakelsesmengde', () => {
     ...stottetTiltakDeltaker,
     deltakerliste: {
       ...stottetTiltakDeltaker.deltakerliste,
-      tiltakskode: Tiltakskode.OPPFOLGING
+      tiltakskodeResponse: {
+        kode: Tiltakskode.OPPFOLGING,
+        visningsnavn: 'Oppfølging'
+      }
     }
   }
 

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
@@ -45,12 +45,12 @@ export const DeltakerInfo = ({ className }: Props) => {
     dato = formatDate(deltaker.startdato)
   }
 
-  const tiltakskode = deltaker.deltakerliste.tiltakskodeResponse
+  const { tiltakskodeResponse } = deltaker.deltakerliste
   const visDeltMedArrangor =
     deltaker.erManueltDeltMedArrangor &&
     kanDeleDeltakerMedArrangorForVurdering(
       deltaker.deltakerliste.pameldingstype,
-      tiltakskode.kode,
+      tiltakskodeResponse.kode,
       deltaker.deltakerliste.erEnkeltplass
     ) &&
     (deltaker.status.type === DeltakerStatusType.SOKT_INN ||
@@ -109,7 +109,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       )}
 
       <OmKurset
-        tiltakskode={tiltakskode.kode}
+        tiltakskode={tiltakskodeResponse.kode}
         statusType={deltaker.status.type}
         oppstartstype={deltaker.deltakerliste.oppstartstype}
         pameldingstype={deltaker.deltakerliste.pameldingstype}
@@ -129,7 +129,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       <AktiveForslag className="mt-8" forslag={deltaker.forslag} />
 
       <DeltakelseInnhold
-        tiltakskode={tiltakskode.kode}
+        tiltakskode={tiltakskodeResponse.kode}
         deltakelsesinnhold={deltaker.deltakelsesinnhold}
         opplaringKategoriseringValg={
           deltaker.deltakerliste.opplaringKategoriseringValg
@@ -165,7 +165,7 @@ export const DeltakerInfo = ({ className }: Props) => {
 
       <SeEndringer
         className="mt-8"
-        tiltakskode={tiltakskode.kode}
+        tiltakskode={tiltakskodeResponse.kode}
         erEnkeltplass={deltaker.deltakerliste.erEnkeltplass}
         deltakerId={deltaker.deltakerId}
         fetchHistorikk={getHistorikk}
@@ -176,7 +176,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       <VedtakOgKlage
         statusType={deltaker.status.type}
         statusDato={deltaker.status.opprettet}
-        tiltakskode={tiltakskode.kode}
+        tiltakskode={tiltakskodeResponse.kode}
         oppstartstype={deltaker.deltakerliste.oppstartstype}
         vedtaksinformasjon={deltaker.vedtaksinformasjon}
         importertFraArena={deltaker.importertFraArena}
@@ -185,7 +185,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       <HvaDelesMedArrangor
         arrangorNavn={deltaker.deltakerliste.arrangorNavn}
         adresseDelesMedArrangor={deltaker.adresseDelesMedArrangor}
-        tiltakskode={tiltakskode.kode}
+        tiltakskode={tiltakskodeResponse.kode}
         statusType={deltaker.status.type}
         oppstartstype={deltaker.deltakerliste.oppstartstype}
         pameldingstype={deltaker.deltakerliste.pameldingstype}

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
@@ -45,12 +45,12 @@ export const DeltakerInfo = ({ className }: Props) => {
     dato = formatDate(deltaker.startdato)
   }
 
-  const tiltakskode = deltaker.deltakerliste.tiltakskodeResponse.kode
+  const tiltakskode = deltaker.deltakerliste.tiltakskodeResponse
   const visDeltMedArrangor =
     deltaker.erManueltDeltMedArrangor &&
     kanDeleDeltakerMedArrangorForVurdering(
       deltaker.deltakerliste.pameldingstype,
-      tiltakskode,
+      tiltakskode.kode,
       deltaker.deltakerliste.erEnkeltplass
     ) &&
     (deltaker.status.type === DeltakerStatusType.SOKT_INN ||
@@ -109,7 +109,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       )}
 
       <OmKurset
-        tiltakskode={tiltakskode}
+        tiltakskode={tiltakskode.kode}
         statusType={deltaker.status.type}
         oppstartstype={deltaker.deltakerliste.oppstartstype}
         pameldingstype={deltaker.deltakerliste.pameldingstype}
@@ -129,7 +129,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       <AktiveForslag className="mt-8" forslag={deltaker.forslag} />
 
       <DeltakelseInnhold
-        tiltakskode={tiltakskode}
+        tiltakskode={tiltakskode.kode}
         deltakelsesinnhold={deltaker.deltakelsesinnhold}
         opplaringKategoriseringValg={
           deltaker.deltakerliste.opplaringKategoriseringValg
@@ -154,7 +154,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       />
 
       <DeltakelsesmengdeInfo
-        tiltakskode={deltaker.deltakerliste.tiltakskode}
+        tiltakskode={deltaker.deltakerliste.tiltakskodeResponse.kode}
         deltakelsesprosent={deltaker.deltakelsesprosent}
         dagerPerUke={deltaker.dagerPerUke}
         erEnkeltplass={deltaker.deltakerliste.erEnkeltplass}
@@ -165,7 +165,7 @@ export const DeltakerInfo = ({ className }: Props) => {
 
       <SeEndringer
         className="mt-8"
-        tiltakskode={tiltakskode}
+        tiltakskode={tiltakskode.kode}
         erEnkeltplass={deltaker.deltakerliste.erEnkeltplass}
         deltakerId={deltaker.deltakerId}
         fetchHistorikk={getHistorikk}
@@ -176,7 +176,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       <VedtakOgKlage
         statusType={deltaker.status.type}
         statusDato={deltaker.status.opprettet}
-        tiltakskode={tiltakskode}
+        tiltakskode={tiltakskode.kode}
         oppstartstype={deltaker.deltakerliste.oppstartstype}
         vedtaksinformasjon={deltaker.vedtaksinformasjon}
         importertFraArena={deltaker.importertFraArena}
@@ -185,7 +185,7 @@ export const DeltakerInfo = ({ className }: Props) => {
       <HvaDelesMedArrangor
         arrangorNavn={deltaker.deltakerliste.arrangorNavn}
         adresseDelesMedArrangor={deltaker.adresseDelesMedArrangor}
-        tiltakskode={tiltakskode}
+        tiltakskode={tiltakskode.kode}
         statusType={deltaker.status.type}
         oppstartstype={deltaker.deltakerliste.oppstartstype}
         pameldingstype={deltaker.deltakerliste.pameldingstype}

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.test.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.test.tsx
@@ -14,7 +14,10 @@ describe('UtkastDeltaker - Deltakelsesmengde', () => {
     ...stottetTiltakDeltaker,
     deltakerliste: {
       ...stottetTiltakDeltaker.deltakerliste,
-      tiltakskode: Tiltakskode.OPPFOLGING
+      tiltakskodeResponse: {
+        kode: Tiltakskode.OPPFOLGING,
+        visningsnavn: 'Oppfølging'
+      }
     }
   }
 

--- a/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.tsx
+++ b/apps/nav-veileders-flate/src/components/utkast/UtkastDeltaker.tsx
@@ -13,7 +13,8 @@ import { useDeltakerContext } from '../tiltak/DeltakerContext.tsx'
 
 export const UtkastDeltaker = () => {
   const { deltaker } = useDeltakerContext()
-  const { tiltakskode, erEnkeltplass } = deltaker.deltakerliste
+  const { tiltakskodeResponse, erEnkeltplass } = deltaker.deltakerliste
+  const tiltakskode = tiltakskodeResponse.kode
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -102,7 +102,6 @@ export class MockHandler {
       deltakerliste: {
         deltakerlisteId: deltakerlisteId,
         deltakerlisteNavn: 'Testliste',
-        tiltakskode: this.tiltakskode,
         tiltakskodeResponse: {
           kode: this.tiltakskode,
           visningsnavn: mockVisningsnavn(this.tiltakskode)
@@ -492,7 +491,6 @@ export class MockHandler {
       tiltakskode === Tiltakskode.NORSKOPPLAERING_GRUNNLEGGENDE_FERDIGHETER_FOV
 
     if (oppdatertPamelding) {
-      oppdatertPamelding.deltakerliste.tiltakskode = tiltakskode
       oppdatertPamelding.deltakerliste.tiltakskodeResponse = {
         kode: tiltakskode,
         visningsnavn: mockVisningsnavn(tiltakskode)

--- a/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
+++ b/apps/nav-veileders-flate/src/utils/endreDeltakelse.ts
@@ -4,7 +4,7 @@ import {
   DeltakerStatusType,
   EndreDeltakelseType,
   harBakgrunnsinfo,
-  harDeltakelsesmengde,
+  harDeltakerlisteDeltakelsesmengde,
   harInnhold,
   harLopendeOppstart
 } from 'deltaker-flate-common'
@@ -47,7 +47,7 @@ const skalViseEndreSluttarsakKnapp = (deltaker: DeltakerResponse) =>
   deltaker.status.type === DeltakerStatusType.IKKE_AKTUELL
 
 const skalViseEndreDeltakelsesmengde = (deltaker: DeltakerResponse) =>
-  harDeltakelsesmengde(deltaker.deltakerliste) &&
+  harDeltakerlisteDeltakelsesmengde(deltaker.deltakerliste) &&
   (venterDeltarEllerAvsluttet(deltaker) || erEnkeltplassSoktInn(deltaker))
 
 const skalViseEndrePrisOgBetaling = (deltaker: DeltakerResponse) =>

--- a/apps/nav-veileders-flate/src/utils/pamelding-form-utils.ts
+++ b/apps/nav-veileders-flate/src/utils/pamelding-form-utils.ts
@@ -1,6 +1,6 @@
 import {
   erOpplaringstiltak,
-  harDeltakelsesmengde,
+  harDeltakerlisteDeltakelsesmengde,
   INNHOLD_TYPE_ANNET,
   Tiltakskode
 } from 'deltaker-flate-common'
@@ -59,7 +59,7 @@ const getDeltakerProsent = (
     data.deltakelsesprosentValg === DeltakelsesprosentValg.JA
       ? 100
       : data.deltakelsesprosent
-  return harDeltakelsesmengde(deltaker.deltakerliste)
+  return harDeltakerlisteDeltakelsesmengde(deltaker.deltakerliste)
     ? deltakelsesprosent
     : undefined
 }

--- a/apps/nav-veileders-flate/src/utils/varighet.test.ts
+++ b/apps/nav-veileders-flate/src/utils/varighet.test.ts
@@ -34,7 +34,6 @@ const pamelding: DeltakerResponse = {
   deltakerliste: {
     deltakerlisteId: uuidv4(),
     deltakerlisteNavn: 'Testliste',
-    tiltakskode: Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
     tiltakskodeResponse: {
       kode: Tiltakskode.ARBEIDSFORBEREDENDE_TRENING,
       visningsnavn: 'Arbeidsforberedende trening'

--- a/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
+++ b/apps/tiltakskoordinator-flate/src/DeltakerListeGuard.tsx
@@ -41,7 +41,7 @@ export const DeltakerListeGuard = () => {
         getFilterStatuser(
           deltakerlisteDetaljerQuery.data.oppstartstype,
           deltakerlisteDetaljerQuery.data.pameldingstype,
-          deltakerlisteDetaljerQuery.data.tiltakskode
+          deltakerlisteDetaljerQuery.data.tiltakskodeResponse.kode
         )
       )
     ]

--- a/apps/tiltakskoordinator-flate/src/api/data/deltaker.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltaker.ts
@@ -5,7 +5,6 @@ import {
   nullableDateSchema,
   Oppstartstype,
   Pameldingstype,
-  Tiltakskode,
   tiltakskodeResponseSchema,
   Vurderingstype
 } from 'deltaker-flate-common'
@@ -52,7 +51,6 @@ export const deltakerDetaljerSchema = z.object({
   beskyttelsesmarkering: z.array(z.enum(Beskyttelsesmarkering)),
   vurdering: vurderingSchema.nullable(),
   innsatsgruppe: z.enum(InnsatsbehovType).nullable(),
-  tiltakskode: z.enum(Tiltakskode),
   tiltakskodeResponse: tiltakskodeResponseSchema,
   oppstartstype: z.enum(Oppstartstype).nullable(),
   pameldingstype: z.enum(Pameldingstype),

--- a/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
+++ b/apps/tiltakskoordinator-flate/src/api/data/deltakerliste.ts
@@ -4,7 +4,6 @@ import {
   nullableDateSchema,
   Oppstartstype,
   Pameldingstype,
-  Tiltakskode,
   tiltakskodeResponseSchema,
   Vurderingstype
 } from 'deltaker-flate-common'
@@ -65,7 +64,6 @@ const koordinatorSchema = z.object({
 export const deltakerlisteDetaljerSchema = z.object({
   id: z.uuid(),
   navn: z.string(),
-  tiltakskode: z.enum(Tiltakskode),
   tiltakskodeResponse: tiltakskodeResponseSchema,
   startdato: nullableDateSchema,
   sluttdato: nullableDateSchema,

--- a/apps/tiltakskoordinator-flate/src/components/deltaker-detaljer/DeltakerDetaljer.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/deltaker-detaljer/DeltakerDetaljer.tsx
@@ -23,7 +23,7 @@ export const DeltakerDetaljer = ({ deltaker }: Props) => {
 
   const visVurdering = kanDeleDeltakerMedArrangorForVurdering(
     deltaker.pameldingstype,
-    deltaker.tiltakskode,
+    deltaker.tiltakskodeResponse.kode,
     /*
         dataene er ikke tilgjengelige i dette endepunktet enda,
         funksjonalitet er ekvivalent som tidligere
@@ -92,7 +92,7 @@ export const DeltakerDetaljer = ({ deltaker }: Props) => {
         <SeEndringer
           className="mt-4 w-fit"
           deltakerId={deltaker.id}
-          tiltakskode={deltaker.tiltakskode}
+          tiltakskode={deltaker.tiltakskodeResponse.kode}
           fetchHistorikk={getDeltakerHistorikk}
           erEnkeltplass={deltaker.erEnkeltplass}
         />

--- a/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.test.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { Pameldingstype } from 'deltaker-flate-common'
+import {
+  Oppstartstype,
+  Pameldingstype,
+  Tiltakskode
+} from 'deltaker-flate-common'
 import { MemoryRouter } from 'react-router-dom'
-import { Deltaker } from '../../api/data/deltakerliste'
+import { Deltaker, DeltakerlisteDetaljer } from '../../api/data/deltakerliste'
 import { DeltakerlisteTabell } from './DeltakerlisteTabell'
 
 import { lagTestDeltaker } from '../../test-utils/lagTestDeltaker'
@@ -10,11 +14,14 @@ import { lagTestDeltaker } from '../../test-utils/lagTestDeltaker'
 const lagDeltaker = (id: string, fornavn: string, etternavn: string) =>
   lagTestDeltaker({ id, fornavn, etternavn })
 
-const deltakerlisteDetaljer = {
+const deltakerlisteDetaljer: Partial<DeltakerlisteDetaljer> = {
   id: 'liste-id',
   pameldingstype: Pameldingstype.TRENGER_GODKJENNING,
-  oppstartstype: 'LOPENDE',
-  tiltakskode: 'GRUPPE_ARBEIDSMARKEDSOPPLAERING',
+  oppstartstype: Oppstartstype.LOPENDE,
+  tiltakskodeResponse: {
+    kode: Tiltakskode.ARBEIDSMARKEDSOPPLAERING,
+    visningsnavn: 'Arbeidsmarkedsopplæring'
+  },
   erEnkeltplass: false
 }
 

--- a/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/deltaker-liste-tabell/DeltakerlisteTabell.tsx
@@ -68,7 +68,7 @@ export const DeltakerlisteTabell = ({
   const skalViseVurderinger =
     kanDeleDeltakerMedArrangorForVurdering(
       deltakerlisteDetaljer.pameldingstype,
-      deltakerlisteDetaljer.tiltakskode,
+      deltakerlisteDetaljer.tiltakskodeResponse.kode,
       deltakerlisteDetaljer.erEnkeltplass
     ) &&
     !!deltakere.find(

--- a/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/filter-deltakerliste/StatusFilter.tsx
@@ -16,7 +16,7 @@ export const StatusFilter = () => {
         getFilterStatuser(
           deltakerlisteDetaljer.oppstartstype,
           deltakerlisteDetaljer.pameldingstype,
-          deltakerlisteDetaljer.tiltakskode
+          deltakerlisteDetaljer.tiltakskodeResponse.kode
         )
       )
     ].map((filtervalg) => ({
@@ -26,7 +26,7 @@ export const StatusFilter = () => {
   }, [
     deltakerlisteDetaljer.oppstartstype,
     deltakerlisteDetaljer.pameldingstype,
-    deltakerlisteDetaljer.tiltakskode
+    deltakerlisteDetaljer.tiltakskodeResponse.kode
   ])
 
   return (

--- a/apps/tiltakskoordinator-flate/src/components/handling/HandlingerKnapp.tsx
+++ b/apps/tiltakskoordinator-flate/src/components/handling/HandlingerKnapp.tsx
@@ -31,7 +31,7 @@ export const HandlingerKnapp = ({ onModalOpen, className }: Props) => {
   const { erKometMasterForTiltak } = useFeatureToggles()
   const { containerElement } = useShadowDom()
   const kometErMaster = erKometMasterForTiltak(
-    deltakerlisteDetaljer.tiltakskode
+    deltakerlisteDetaljer.tiltakskodeResponse.kode
   )
   const handlingValgRef = useRef<HandlingValg | null>(null)
   const handlingKnappRef = useRef<HTMLButtonElement>(null)
@@ -62,7 +62,7 @@ export const HandlingerKnapp = ({ onModalOpen, className }: Props) => {
 
   const kanDeleMedArrangor = kanDeleDeltakerMedArrangorForVurdering(
     deltakerlisteDetaljer.pameldingstype,
-    deltakerlisteDetaljer.tiltakskode,
+    deltakerlisteDetaljer.tiltakskodeResponse.kode,
     deltakerlisteDetaljer.erEnkeltplass
   )
 

--- a/apps/tiltakskoordinator-flate/src/mocks/mockData.tsx
+++ b/apps/tiltakskoordinator-flate/src/mocks/mockData.tsx
@@ -126,7 +126,6 @@ export const createMockDeltaker = (
       epost: 'veileder.veiledersen@epost.no'
     },
     innsatsgruppe: InnsatsbehovType.STANDARD_INNSATS,
-    tiltakskode: Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
     tiltakskodeResponse: {
       kode: Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
       visningsnavn: mockVisningsnavn(
@@ -229,7 +228,6 @@ export const createMockDeltakerlisteDetaljer = (): DeltakerlisteDetaljer => {
   return {
     id: uuidv4(),
     navn: 'Kometrytter Kurs',
-    tiltakskode: Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
     tiltakskodeResponse: {
       kode: Tiltakskode.GRUPPE_ARBEIDSMARKEDSOPPLAERING,
       visningsnavn: mockVisningsnavn(

--- a/packages/deltaker-flate-common/utils/utils.ts
+++ b/packages/deltaker-flate-common/utils/utils.ts
@@ -5,7 +5,8 @@ import {
   DeltakerStatusAarsakType,
   Oppstartstype,
   Pameldingstype,
-  Tiltakskode
+  Tiltakskode,
+  TiltakskodeResponse
 } from '../model/deltaker'
 import { Prisinformasjon, PrisinformasjonType } from '../model/prisinformasjon'
 import { EMDASH } from './constants'
@@ -128,6 +129,16 @@ export const formatDateFromString = (
   const date = dayjs(dateStr)
   return date.isValid() ? date.format('DD.MM.YYYY') : EMDASH
 }
+
+export const harDeltakerlisteDeltakelsesmengde = (arg: {
+  // Delmengde av deltakerliste-typen
+  tiltakskodeResponse: TiltakskodeResponse
+  erEnkeltplass: boolean
+}) =>
+  harDeltakelsesmengde({
+    tiltakskode: arg.tiltakskodeResponse.kode,
+    erEnkeltplass: arg.erEnkeltplass
+  })
 
 export const harDeltakelsesmengde = ({
   tiltakskode,


### PR DESCRIPTION
Dette er bare et mellomsteg for å frigjøre deltakerliste.tiltakskode til å kunne eksponere den nye response-typen uten "Response" i navnet.