### PR TITLE
Lagt til tilbakekall prisendring

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,3 @@ I dev er oppsettet forskjellig per app, avhengig av hvor appen er integrert:
 | `tiltakskoordinator-flate` | Nav tiltaksadministrasjon                        | Navs CDN                       |
 | `nav-veileders-flate`      | Modia                                            | Navs CDN (i dev)               |
 | `innbyggers-flate`         | Selvstendig app, lenkes til fra aktivitetsplanen | Egen kjørende instans          |
-
-![img.png](img.png)

--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ I dev er oppsettet forskjellig per app, avhengig av hvor appen er integrert:
 | `nav-veileders-flate`      | Modia                                            | Navs CDN (i dev)               |
 | `innbyggers-flate`         | Selvstendig app, lenkes til fra aktivitetsplanen | Egen kjørende instans          |
 
-> ⚠️ **Merk:** I prod hentes `nav-veileders-flate` fra den kjørende instansen i stedet for Navs CDN. Dette bør på sikt endres slik at prod og dev fungerer likt.
+![img.png](img.png)

--- a/apps/nav-veileders-flate/src/api/api-enkeltplass.ts
+++ b/apps/nav-veileders-flate/src/api/api-enkeltplass.ts
@@ -227,6 +227,27 @@ export const sokUnderenhet = async (
     })
 }
 
+export const tilbakekallPrisendring = (
+  deltakerId: string,
+  enhetId: string
+): Promise<number> => {
+  return fetch(`${API_URL}/enkeltplass/tilbakekall-prisendring/${deltakerId}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'aktiv-enhet': enhetId
+    }
+  }).then((response) => {
+    if (response.status !== 200) {
+      const message = 'Kunne ikke tilbakekalle prisendringen.'
+      handleError(message, deltakerId, response.status)
+    }
+    return response.status
+  })
+}
+
 export const sokSertifiseringer = async (
   term: string,
   enhetId: string

--- a/apps/nav-veileders-flate/src/api/data/deltaker.ts
+++ b/apps/nav-veileders-flate/src/api/data/deltaker.ts
@@ -48,8 +48,9 @@ export const deltakerlisteSchema = z.object({
   oppmoteSted: z.string().nullable(),
   pameldingstype: z.enum(Pameldingstype),
   opplaringKategoriseringValg: opplaringKategoriseringSchema.nullable(),
+  visningsnavn: visningsnavnSchema,
   prisinformasjon: prisinformasjonSchema.nullish(),
-  visningsnavn: visningsnavnSchema
+  prisinformasjonTilGodkjenning: prisinformasjonSchema.nullish()
 })
 
 export const deltakerSchema = z.object({

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.test.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.test.tsx
@@ -1,12 +1,19 @@
 import '@testing-library/jest-dom'
-import { screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
-import { DeltakerStatusType, Tiltakskode } from 'deltaker-flate-common'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DeltakerStatusType,
+  PrisinformasjonType,
+  Tiltakskode
+} from 'deltaker-flate-common'
 import {
   lagDeltaker,
   renderWithDeltakerContext
 } from '../test-utils/deltaker-context-test-utils'
 import { DeltakerInfo } from './DeltakerInfo'
+import { AppContext } from '../../AppContext.tsx'
+import { DeltakerContext } from './DeltakerContext.tsx'
+import { DeltakerResponse } from '../../api/data/deltaker.ts'
 
 describe('DeltakerInfo - Deltakelsesmengde', () => {
   const baseStatus = {
@@ -45,5 +52,57 @@ describe('DeltakerInfo - Deltakelsesmengde', () => {
       ikkeStottetTiltakDeltaker
     )
     expect(screen.queryByText('Deltakelsesmengde')).not.toBeInTheDocument()
+  })
+})
+
+describe('DeltakerInfo - PrisinformasjonTilGodkjenning', () => {
+  const appContextValue = {
+    personident: 'p1',
+    enhetId: 'e1',
+    setPersonident: vi.fn(),
+    setEnhetId: vi.fn()
+  }
+
+  const renderMedPrisinformasjon = (deltaker: DeltakerResponse) =>
+    render(
+      <AppContext.Provider value={appContextValue}>
+        <DeltakerContext.Provider value={{ deltaker, setDeltaker: vi.fn() }}>
+          <DeltakerInfo className="" />
+        </DeltakerContext.Provider>
+      </AppContext.Provider>
+    )
+
+  it('viser seksjon for prisinformasjon til godkjenning med handlingsknapper', () => {
+    const deltaker = lagDeltaker(
+      {},
+      {
+        prisinformasjonTilGodkjenning: {
+          type: PrisinformasjonType.Anskaffelse,
+          pris: 5000
+        }
+      }
+    )
+
+    renderMedPrisinformasjon(deltaker)
+
+    expect(
+      screen.getByText('Forslag sendt til godkjenning:')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Tilbakekall forslag' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Endre forslag' })
+    ).toBeInTheDocument()
+  })
+
+  it('skjuler seksjon for prisinformasjon til godkjenning når feltet ikke er satt', () => {
+    const deltaker = lagDeltaker()
+
+    renderMedPrisinformasjon(deltaker)
+
+    expect(
+      screen.queryByText('Forslag sendt til godkjenning:')
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/DeltakerInfo.tsx
@@ -22,6 +22,7 @@ import { getHistorikk } from '../../api/api.ts'
 import { DIALOG_URL } from '../../utils/environment-utils.ts'
 import { useDeltakerContext } from './DeltakerContext.tsx'
 import { AktiveForslag } from './forslag/AktiveForslag.tsx'
+import { PrisinformasjonTilGodkjenning } from './forslag/PrisinformasjonTilGodkjenning.tsx'
 
 interface Props {
   className: string
@@ -127,6 +128,15 @@ export const DeltakerInfo = ({ className }: Props) => {
       />
 
       <AktiveForslag className="mt-8" forslag={deltaker.forslag} />
+
+      {deltaker.deltakerliste.prisinformasjonTilGodkjenning && (
+        <PrisinformasjonTilGodkjenning
+          className="mt-8"
+          prisinformasjonTilGodkjenning={
+            deltaker.deltakerliste.prisinformasjonTilGodkjenning
+          }
+        />
+      )}
 
       <DeltakelseInnhold
         tiltakskode={tiltakskode.kode}

--- a/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndrePrisinfoModal.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/endre-deltakelse-modaler/EndrePrisinfoModal.tsx
@@ -2,6 +2,7 @@ import {
   BegrunnelseInput,
   DeltakerStatusType,
   EndreDeltakelseType,
+  Prisinformasjon,
   useBegrunnelse
 } from 'deltaker-flate-common'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -26,6 +27,7 @@ interface Props {
   open: boolean
   onClose: () => void
   onSuccess: (oppdatertDeltaker: DeltakerResponse | null) => void
+  initialPrisinformasjon?: Prisinformasjon | null
 }
 
 // TODO må håndtere å åpne et eksisterende "forslag"
@@ -33,13 +35,17 @@ export const EndrePrisinfoModal = ({
   deltaker,
   open,
   onClose,
-  onSuccess
+  onSuccess,
+  initialPrisinformasjon
 }: Props) => {
   const { enhetId } = useAppContext()
   const begrunnelse = useBegrunnelse(false)
   const laasPristype = deltaker.status.type !== DeltakerStatusType.SOKT_INN
 
-  const defaultValues = generatePrisinformasjonDefaultValues(deltaker)
+  const defaultValues = generatePrisinformasjonDefaultValues(
+    deltaker,
+    initialPrisinformasjon
+  )
   const formMethods = useForm<PrisinformasjonFormValues>({
     defaultValues,
     resolver: zodResolver(createPrisinformasjonFormSchema()),

--- a/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
@@ -1,0 +1,131 @@
+import { Box, Button, Heading, HGrid, Tag, VStack } from '@navikt/ds-react'
+import {
+  ACTION_BLUE_TAG_STYLE,
+  EndringerBox,
+  EndringerWrapper,
+  EndreDeltakelseType,
+  EndringTypeIkon,
+  getEndreDeltakelseTypeText,
+  Prisinformasjon,
+  PrisOgBetaling
+} from 'deltaker-flate-common'
+import { useState } from 'react'
+import { DeltakerResponse } from '../../../api/data/deltaker.ts'
+import { tilbakekallPrisendring } from '../../../api/api-enkeltplass.ts'
+import { useAppContext } from '../../../AppContext.tsx'
+import { useDeltakerContext } from '../DeltakerContext.tsx'
+import { ModalController } from '../endre-deltakelse-modaler/ModalController.tsx'
+
+export const PrisinformasjonTilGodkjenning = ({
+  prisinformasjonTilGodkjenning,
+  className
+}: {
+  prisinformasjonTilGodkjenning: Prisinformasjon
+  className?: string
+}) => {
+  const { enhetId } = useAppContext()
+  const { deltaker, setDeltaker } = useDeltakerContext()
+  const [endreModalOpen, setEndreModalOpen] = useState(false)
+  const [laster, setLaster] = useState(false)
+
+  const handleEndringUtfort = (oppdatertDeltaker: DeltakerResponse | null) => {
+    setEndreModalOpen(false)
+    if (oppdatertDeltaker) {
+      setDeltaker(oppdatertDeltaker)
+    }
+  }
+
+  const handleTilbakekall = async () => {
+    setLaster(true)
+    try {
+      await tilbakekallPrisendring(deltaker.deltakerId, enhetId)
+      const oppdatertDeltaker: DeltakerResponse = {
+        ...deltaker,
+        deltakerliste: {
+          ...deltaker.deltakerliste,
+          prisinformasjonTilGodkjenning: null
+        }
+      }
+      setDeltaker(oppdatertDeltaker)
+    } finally {
+      setLaster(false)
+    }
+  }
+
+  return (
+    <EndringerWrapper className={className ?? ''}>
+      <VStack gap="space-16">
+        <Heading level="2" size="medium">
+          Forslag sendt til godkjenning:
+        </Heading>
+        <EndringerBox>
+          <HGrid columns="2rem auto" className="p-4 items-start">
+            <EndringTypeIkon
+              type={EndreDeltakelseType.ENDRE_PRISINFO}
+              size="large"
+            />
+            <VStack className="items-start">
+              <div className="flex gap-8 mb-2">
+                <Heading level="3" size="small">
+                  {getEndreDeltakelseTypeText(
+                    EndreDeltakelseType.ENDRE_PRISINFO
+                  )}
+                </Heading>
+                <Tag
+                  variant="outline"
+                  className={ACTION_BLUE_TAG_STYLE}
+                  size="small"
+                >
+                  Venter på godkjenning
+                </Tag>
+              </div>
+              <PrisOgBetaling
+                prisinformasjon={prisinformasjonTilGodkjenning}
+                headinglevel="3"
+                showHeading={false}
+                showTilleggsstonaderInfo={false}
+              />
+            </VStack>
+          </HGrid>
+          <Box
+            className="bg-(--ax-bg-accent-moderate) p-2"
+            borderRadius="0 0 4 4"
+          >
+            <div className="flex items-center">
+              <Heading level="3" size="xsmall">
+                For Nav-ansatt:
+              </Heading>
+              <Button
+                size="small"
+                variant="primary"
+                className="ml-4"
+                onClick={() => setEndreModalOpen(true)}
+                disabled={!deltaker.kanEndres}
+              >
+                Endre forslag
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
+                className="ml-2"
+                onClick={handleTilbakekall}
+                loading={laster}
+              >
+                Tilbakekall forslag
+              </Button>
+            </div>
+          </Box>
+        </EndringerBox>
+      </VStack>
+
+      <ModalController
+        endringsType={EndreDeltakelseType.ENDRE_PRISINFO}
+        open={endreModalOpen}
+        onClose={() => setEndreModalOpen(false)}
+        onSuccess={handleEndringUtfort}
+        deltaker={deltaker}
+        forslag={null}
+      />
+    </EndringerWrapper>
+  )
+}

--- a/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
@@ -1,13 +1,23 @@
-import { Box, Button, Heading, HGrid, Tag, VStack } from '@navikt/ds-react'
+import {
+  Alert,
+  Box,
+  Button,
+  Heading,
+  HGrid,
+  Tag,
+  VStack
+} from '@navikt/ds-react'
 import {
   ACTION_BLUE_TAG_STYLE,
+  DeferredFetchState,
   EndringerBox,
   EndringerWrapper,
   EndreDeltakelseType,
   EndringTypeIkon,
   getEndreDeltakelseTypeText,
   Prisinformasjon,
-  PrisOgBetaling
+  PrisOgBetaling,
+  useDeferredFetch
 } from 'deltaker-flate-common'
 import { useState } from 'react'
 import { DeltakerResponse } from '../../../api/data/deltaker.ts'
@@ -26,7 +36,12 @@ export const PrisinformasjonTilGodkjenning = ({
   const { enhetId } = useAppContext()
   const { deltaker, setDeltaker } = useDeltakerContext()
   const [endreModalOpen, setEndreModalOpen] = useState(false)
-  const [laster, setLaster] = useState(false)
+
+  const {
+    state: tilbakekallState,
+    error: tilbakekallFeil,
+    doFetch: doTilbakekall
+  } = useDeferredFetch(tilbakekallPrisendring)
 
   const handleEndringUtfort = (oppdatertDeltaker: DeltakerResponse | null) => {
     setEndreModalOpen(false)
@@ -35,21 +50,20 @@ export const PrisinformasjonTilGodkjenning = ({
     }
   }
 
-  const handleTilbakekall = async () => {
-    setLaster(true)
-    try {
-      await tilbakekallPrisendring(deltaker.deltakerId, enhetId)
-      const oppdatertDeltaker: DeltakerResponse = {
-        ...deltaker,
-        deltakerliste: {
-          ...deltaker.deltakerliste,
-          prisinformasjonTilGodkjenning: null
-        }
-      }
-      setDeltaker(oppdatertDeltaker)
-    } finally {
-      setLaster(false)
-    }
+  const handleTilbakekall = () => {
+    doTilbakekall(deltaker.deltakerId, enhetId)
+      .then(() => {
+        setDeltaker({
+          ...deltaker,
+          deltakerliste: {
+            ...deltaker.deltakerliste,
+            prisinformasjonTilGodkjenning: null
+          }
+        })
+      })
+      .catch(() => {
+        // Feil vises via tilbakekallFeil
+      })
   }
 
   return (
@@ -109,22 +123,29 @@ export const PrisinformasjonTilGodkjenning = ({
                 variant="secondary"
                 className="ml-2"
                 onClick={handleTilbakekall}
-                loading={laster}
+                loading={tilbakekallState === DeferredFetchState.LOADING}
               >
                 Tilbakekall forslag
               </Button>
             </div>
+            {tilbakekallFeil && (
+              <Alert size="small" variant="error" className="mt-2">
+                Kunne ikke tilbakekalle forslaget. Prøv igjen.
+              </Alert>
+            )}
           </Box>
         </EndringerBox>
       </VStack>
 
-      <EndrePrisinfoModal
-        open={endreModalOpen}
-        onClose={() => setEndreModalOpen(false)}
-        onSuccess={handleEndringUtfort}
-        deltaker={deltaker}
-        initialPrisinformasjon={prisinformasjonTilGodkjenning}
-      />
+      {endreModalOpen && (
+        <EndrePrisinfoModal
+          open={endreModalOpen}
+          onClose={() => setEndreModalOpen(false)}
+          onSuccess={handleEndringUtfort}
+          deltaker={deltaker}
+          initialPrisinformasjon={prisinformasjonTilGodkjenning}
+        />
+      )}
     </EndringerWrapper>
   )
 }

--- a/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
@@ -53,13 +53,13 @@ export const PrisinformasjonTilGodkjenning = ({
   const handleTilbakekall = () => {
     doTilbakekall(deltaker.deltakerId, enhetId)
       .then(() => {
-        setDeltaker({
-          ...deltaker,
+        setDeltaker((prev) => ({
+          ...prev,
           deltakerliste: {
-            ...deltaker.deltakerliste,
+            ...prev.deltakerliste,
             prisinformasjonTilGodkjenning: null
           }
-        })
+        }))
       })
       .catch(() => {
         // Feil vises via tilbakekallFeil

--- a/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
+++ b/apps/nav-veileders-flate/src/components/tiltak/forslag/PrisinformasjonTilGodkjenning.tsx
@@ -14,7 +14,7 @@ import { DeltakerResponse } from '../../../api/data/deltaker.ts'
 import { tilbakekallPrisendring } from '../../../api/api-enkeltplass.ts'
 import { useAppContext } from '../../../AppContext.tsx'
 import { useDeltakerContext } from '../DeltakerContext.tsx'
-import { ModalController } from '../endre-deltakelse-modaler/ModalController.tsx'
+import { EndrePrisinfoModal } from '../endre-deltakelse-modaler/EndrePrisinfoModal.tsx'
 
 export const PrisinformasjonTilGodkjenning = ({
   prisinformasjonTilGodkjenning,
@@ -118,13 +118,12 @@ export const PrisinformasjonTilGodkjenning = ({
         </EndringerBox>
       </VStack>
 
-      <ModalController
-        endringsType={EndreDeltakelseType.ENDRE_PRISINFO}
+      <EndrePrisinfoModal
         open={endreModalOpen}
         onClose={() => setEndreModalOpen(false)}
         onSuccess={handleEndringUtfort}
         deltaker={deltaker}
-        forslag={null}
+        initialPrisinformasjon={prisinformasjonTilGodkjenning}
       />
     </EndringerWrapper>
   )

--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -25,7 +25,8 @@ import {
   Oppstartstype,
   Pameldingstype,
   PrisinformasjonType,
-  Tiltakskode
+  Tiltakskode,
+  Tilskuddstype
 } from 'deltaker-flate-common'
 import { HttpResponse } from 'msw'
 import { v4 as uuidv4 } from 'uuid'
@@ -132,6 +133,18 @@ export class MockHandler {
               type: PrisinformasjonType.IngenKostnader,
               aarsak: IngenKostnaderAarsak.OPPLAERINGEN_ER_KOSTNADSFRI,
               tilleggsopplysninger: null
+            }
+          : null,
+        prisinformasjonTilGodkjenning: erEnkeltplass
+          ? {
+              type: PrisinformasjonType.Tilskudd,
+              tilskudd: [
+                { type: Tilskuddstype.SEMESTERAVGIFT, pris: 2500 },
+                { type: Tilskuddstype.SKOLEPENGER, pris: 31000 },
+                { type: Tilskuddstype.EKSAMENSGEBYR, pris: 3900 }
+              ],
+              tilleggsopplysninger:
+                '[Fritekst: Etter avtale kan du søke Nav om refusjon for de 2 første årene. Det tredje året skal du dekke selv]'
             }
           : null,
         visningsnavn: {
@@ -692,6 +705,10 @@ export class MockHandler {
     }
 
     return new HttpResponse(null, { status: 404 })
+  }
+
+  tilbakekallPrisendring() {
+    return new HttpResponse(null, { status: 200 })
   }
 
   endreDeltakelseFjernOppstartsdato(request: FjernOppstartsdatoRequest) {

--- a/apps/nav-veileders-flate/src/mocks/MockHandler.ts
+++ b/apps/nav-veileders-flate/src/mocks/MockHandler.ts
@@ -708,7 +708,15 @@ export class MockHandler {
   }
 
   tilbakekallPrisendring() {
-    return new HttpResponse(null, { status: 200 })
+    const oppdatertPamelding = this.pamelding
+
+    if (oppdatertPamelding) {
+      oppdatertPamelding.deltakerliste.prisinformasjonTilGodkjenning = null
+      this.pamelding = oppdatertPamelding
+      return new HttpResponse(null, { status: 200 })
+    }
+
+    return new HttpResponse(null, { status: 404 })
   }
 
   endreDeltakelseFjernOppstartsdato(request: FjernOppstartsdatoRequest) {

--- a/apps/nav-veileders-flate/src/mocks/setupMocks.ts
+++ b/apps/nav-veileders-flate/src/mocks/setupMocks.ts
@@ -36,67 +36,52 @@ const handler = new MockHandler()
 export const worker = setupWorker(
   http.post('/amt-deltaker-bff/setup/status/:status', async ({ params }) => {
     const { status } = params
-
-    const response = handler.setStatus(status as DeltakerStatusType)
-    return response
+    return handler.setStatus(status as DeltakerStatusType)
   }),
   http.post(
     '/amt-deltaker-bff/setup/tiltakskode/:tiltakskode',
     async ({ params }) => {
       const { tiltakskode } = params
-
-      const response = handler.setTiltakskode(tiltakskode as Tiltakskode)
-      return response
+      return handler.setTiltakskode(tiltakskode as Tiltakskode)
     }
   ),
   http.post(
     '/amt-deltaker-bff/setup/oppstartstype/:oppstartstype',
     async ({ params }) => {
       const { oppstartstype } = params
-
-      const response = handler.setOppstartstype(oppstartstype as Oppstartstype)
-      return response
+      return handler.setOppstartstype(oppstartstype as Oppstartstype)
     }
   ),
   http.post(
     '/amt-deltaker-bff/setup/pameldingstype/:pameldingstype',
     async ({ params }) => {
       const { pameldingstype } = params
-
-      const response = handler.setPameldingstype(
-        pameldingstype as Pameldingstype
-      )
-      return response
+      return handler.setPameldingstype(pameldingstype as Pameldingstype)
     }
   ),
   http.post(
     '/amt-deltaker-bff/setup/er-enkeltplass/:erEnkeltplass',
     async ({ params }) => {
       const { erEnkeltplass } = params
-
-      const response = handler.setErEnkeltplass(erEnkeltplass === 'true')
-      return response
+      return handler.setErEnkeltplass(erEnkeltplass === 'true')
     }
   ),
   http.post('/amt-deltaker-bff/kladd', async ({ request }) => {
     await delay(1000)
-    const response = await request
+    return await request
       .json()
       .then((json) => opprettKladdRequestSchema.parse(json))
       .then((body) => handler.createPamelding(body.deltakerlisteId))
-
-    return response
   }),
   http.post(
     '/amt-deltaker-bff/enkeltplass/opprett-kladd',
     async ({ request }) => {
       await delay(1000)
-      const response = await request
+
+      return await request
         .json()
         .then((json) => opprettEnkeltplassKladdRequestSchema.parse(json))
         .then((body) => handler.createEnkeltplassPamelding(body.tiltakskode))
-
-      return response
     }
   ),
   http.delete('/amt-deltaker-bff/kladd/:deltakerId', async ({ params }) => {
@@ -107,24 +92,20 @@ export const worker = setupWorker(
   http.post('/amt-deltaker-bff/pamelding/:deltakerId', async ({ request }) => {
     await delay(1000)
 
-    const response = await request
+    return await request
       .json()
       .then((json) => pameldingRequestSchema.parse(json))
       .then((body) => handler.sendInnPamelding(body))
-
-    return response
   }),
   http.post(
     '/amt-deltaker-bff/pamelding/:deltakerId/utenGodkjenning',
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => pameldingRequestSchema.parse(json))
         .then(() => new HttpResponse(null, { status: 200 }))
-
-      return response
     }
   ),
   http.post(
@@ -132,12 +113,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => enkeltplassPameldingSchema.parse(json))
         .then((body) => handler.sendInnPameldingEnkeltplass(body))
-
-      return response
     }
   ),
   http.post(
@@ -145,12 +124,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => enkeltplassPameldingSchema.parse(json))
         .then((body) => handler.sendInnPameldingEnkeltplass(body))
-
-      return response
     }
   ),
   http.post(
@@ -158,12 +135,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => enkeltplassPameldingSchema.parse(json))
         .then(() => new HttpResponse(null, { status: 200 }))
-
-      return response
     }
   ),
   http.post(
@@ -171,12 +146,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(100)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => ikkeAktuellSchema.parse(json))
         .then((body) => handler.endreDeltakelseIkkeAktuell(body))
-
-      return response
     }
   ),
   http.post('/amt-deltaker-bff/deltaker/:deltakerId/reaktiver', async () => {
@@ -187,12 +160,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => forlengDeltakelseSchema.parse(json))
         .then((body) => handler.endreDeltakelseForleng(body))
-
-      return response
     }
   ),
   http.post(
@@ -200,12 +171,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => endreStartdatoSchema.parse(json))
         .then((body) => handler.endreDeltakelseStartdato(body))
-
-      return response
     }
   ),
   http.post(
@@ -213,12 +182,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => endreBakgrunnsinfoSchema.parse(json))
         .then((body) => handler.endreDeltakelseBakgrunnsinfo(body))
-
-      return response
     }
   ),
   http.post(
@@ -226,12 +193,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => endrePrisinfoSchema.parse(json))
         .then((body) => handler.endreDeltakelsePrisinfo(body))
-
-      return response
     }
   ),
   http.post(
@@ -239,12 +204,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => endreInnholdOpplaringKategoriseringSchema.parse(json))
         .then((body) => handler.endreDeltakelseInnholdKodeverk(body))
-
-      return response
     }
   ),
   http.post(
@@ -252,12 +215,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(1000)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => fjernOppstartsdatoSchema.parse(json))
         .then((body) => handler.endreDeltakelseFjernOppstartsdato(body))
-
-      return response
     }
   ),
   http.post(
@@ -265,36 +226,32 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(100)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => endreSluttarsakSchema.parse(json))
         .then((body) => handler.endreDeltakelseSluttarsak(body))
-
-      return response
     }
   ),
   http.post(
     '/amt-deltaker-bff/deltaker/:deltakerId/innhold',
     async ({ request }) => {
       await delay(100)
-      const response = await request
+
+      return await request
         .json()
         .then((json) => endreInnholdSchema.parse(json))
         .then((body) => handler.endreDeltakelseInnhold(body))
-
-      return response
     }
   ),
   http.post(
     '/amt-deltaker-bff/deltaker/:deltakerId/deltakelsesmengde',
     async ({ request }) => {
       await delay(100)
-      const response = await request
+
+      return await request
         .json()
         .then((json) => endreDeltakelsesmengdeSchema.parse(json))
         .then((body) => handler.endreDeltakelsesmengde(body))
-
-      return response
     }
   ),
   http.post(
@@ -302,12 +259,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(100)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => avsluttDeltakelseSchema.parse(json))
         .then((body) => handler.avsluttDeltakelse(body))
-
-      return response
     }
   ),
   http.post(
@@ -315,12 +270,10 @@ export const worker = setupWorker(
     async ({ request }) => {
       await delay(100)
 
-      const response = await request
+      return await request
         .json()
         .then((json) => endreAvslutningSchema.parse(json))
         .then((body) => handler.endreAvslutning(body))
-
-      return response
     }
   ),
   http.post(
@@ -329,10 +282,7 @@ export const worker = setupWorker(
       await delay(1000)
       const { forslagId } = params as { forslagId: string }
 
-      const respone = await request
-        .json()
-        .then(() => handler.avvisForslag(forslagId))
-      return respone
+      return await request.json().then(() => handler.avvisForslag(forslagId))
     }
   ),
   http.post('/amt-deltaker-bff/pamelding/:deltakerId/avbryt', async () => {
@@ -353,12 +303,11 @@ export const worker = setupWorker(
     '/amt-deltaker-bff/enkeltplass/oppdater-kladd/:deltakerId',
     async ({ request }) => {
       await delay(1000)
-      const response = await request
+
+      return await request
         .json()
         .then((json) => enkeltplassKladdSchema.parse(json))
         .then((body) => handler.oppdaterEnkeltplassKladd(body))
-
-      return response
     }
   ),
   http.get('/amt-deltaker-bff/deltaker/:deltakerId/historikk', async () => {
@@ -393,5 +342,12 @@ export const worker = setupWorker(
   http.get('/amt-deltaker-bff/enkeltplass/kodeverk/:deltakerId', async () => {
     await delay(1000)
     return HttpResponse.json(handler.getKodeverk())
-  })
+  }),
+  http.post(
+    '/amt-deltaker-bff/enkeltplass/tilbakekall-prisendring/:deltakerId',
+    async () => {
+      await delay(1000)
+      return handler.tilbakekallPrisendring()
+    }
+  )
 )

--- a/apps/nav-veileders-flate/src/model/PrisinformasjonFormValues.ts
+++ b/apps/nav-veileders-flate/src/model/PrisinformasjonFormValues.ts
@@ -1,5 +1,6 @@
 import {
   IngenKostnaderAarsak,
+  Prisinformasjon,
   prisinformasjonSchema,
   PrisinformasjonType
 } from 'deltaker-flate-common'
@@ -28,11 +29,16 @@ export type PrisinformasjonFormValues = z.infer<
 >
 
 export const generatePrisinformasjonDefaultValues = (
-  deltaker: DeltakerResponse
+  deltaker: DeltakerResponse,
+  initialPrisinformasjon?: Prisinformasjon | null
 ): PrisinformasjonFormValues => {
+  const prisinfo =
+    initialPrisinformasjon !== undefined
+      ? initialPrisinformasjon
+      : deltaker.deltakerliste.prisinformasjon
   return {
-    pristype: deltaker.deltakerliste.prisinformasjon?.type ?? null,
-    prisinformasjon: deltaker.deltakerliste.prisinformasjon ?? null
+    pristype: prisinfo?.type ?? null,
+    prisinformasjon: prisinfo ?? null
   }
 }
 


### PR DESCRIPTION
## Description
Legger til støtte i `nav-veileders-flate` for å kunne tilbakekalle prisendring på enkeltplass, inkludert ny API-funksjon, mock-endepunkt og utvidet deltakerliste-modell.

**Changes:**
- Nytt API-kall `tilbakekallPrisendring` mot BFF-endepunktet for enkeltplass.
- Utvider deltakerliste-modellen med `prisinformasjonTilGodkjenning` og mocker dette i `MockHandler`.
- Oppdaterer MSW-mocks med nytt endepunkt for tilbakekall av prisendring.

## Trello card
https://trello.com/c/XUENhLKJ