### PR TITLE
Økonomi godkjent i historikk

### DIFF
--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.test.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.test.tsx
@@ -9,10 +9,6 @@ const lagEnkeltplassOkonomiGodkjent = (): Extract<
 > =>
   ({
     type: 'EnkeltplassOkonomiGodkjent',
-    prisinformasjon: {
-      type: 'Anskaffelse',
-      pris: 50000
-    },
     endretAv: 'Bernt Besluttersen',
     endretAvEnhet: 'Nav Tiltak Oslo',
     endret: new Date('2026-10-15')

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.test.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.test.tsx
@@ -2,20 +2,17 @@ import { describe, expect, it } from 'vitest'
 import { HistorikkEnkeltplassOkonomiGodkjent } from './HistorikkEnkeltplassOkonomiGodkjent'
 import { extractText } from '../test-utils'
 import { DeltakerHistorikk } from '../../model/deltakerHistorikk'
+import { HistorikkType } from '../../model/forslag'
 
 const lagEnkeltplassOkonomiGodkjent = (): Extract<
   DeltakerHistorikk,
-  { type: 'EnkeltplassOkonomiGodkjent' }
-> =>
-  ({
-    type: 'EnkeltplassOkonomiGodkjent',
-    endretAv: 'Bernt Besluttersen',
-    endretAvEnhet: 'Nav Tiltak Oslo',
-    endret: new Date('2026-10-15')
-  }) as unknown as Extract<
-    DeltakerHistorikk,
-    { type: 'EnkeltplassOkonomiGodkjent' }
-  >
+  { type: HistorikkType.EnkeltplassOkonomiGodkjent }
+> => ({
+  type: HistorikkType.EnkeltplassOkonomiGodkjent,
+  endretAv: 'Bernt Besluttersen',
+  endretAvEnhet: 'Nav Tiltak Oslo',
+  endret: new Date('2026-10-15')
+})
 
 describe('HistorikkEnkeltplassOkonomiGodkjent', () => {
   it('rendrer tittel og innhold korrekt', () => {

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.test.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { HistorikkEnkeltplassOkonomiGodkjent } from './HistorikkEnkeltplassOkonomiGodkjent'
+import { extractText } from '../test-utils'
+import { DeltakerHistorikk } from '../../model/deltakerHistorikk'
+
+const lagEnkeltplassOkonomiGodkjent = (): Extract<
+  DeltakerHistorikk,
+  { type: 'EnkeltplassOkonomiGodkjent' }
+> =>
+  ({
+    type: 'EnkeltplassOkonomiGodkjent',
+    prisinformasjon: {
+      type: 'Anskaffelse',
+      pris: 50000
+    },
+    endretAv: 'Bernt Besluttersen',
+    endretAvEnhet: 'Nav Tiltak Oslo',
+    endret: new Date('2026-10-15')
+  }) as unknown as Extract<
+    DeltakerHistorikk,
+    { type: 'EnkeltplassOkonomiGodkjent' }
+  >
+
+describe('HistorikkEnkeltplassOkonomiGodkjent', () => {
+  it('rendrer tittel og innhold korrekt', () => {
+    const text = extractText(
+      HistorikkEnkeltplassOkonomiGodkjent({
+        endringsHistorikk: lagEnkeltplassOkonomiGodkjent()
+      })
+    ).join(' ')
+
+    expect(text).toContain('Opplæring godkjent')
+    expect(text).toContain('Pris og betalingsbetingelser er godkjent')
+  })
+
+  it('viser når og av hvem økonomien ble godkjent', () => {
+    const text = extractText(
+      HistorikkEnkeltplassOkonomiGodkjent({
+        endringsHistorikk: lagEnkeltplassOkonomiGodkjent()
+      })
+    ).join(' ')
+
+    expect(text).toContain('Bernt Besluttersen')
+    expect(text).toContain('Nav Tiltak Oslo')
+  })
+})

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
@@ -1,0 +1,33 @@
+import { CheckmarkCircleFillIcon } from '@navikt/aksel-icons'
+import { BodyShort, Detail } from '@navikt/ds-react'
+import { DeltakerHistorikk } from '../../model/deltakerHistorikk'
+import { formatDate } from '../../utils/utils'
+import { HistorikkElement } from './HistorikkElement'
+
+interface Props {
+  endringsHistorikk: Extract<
+    DeltakerHistorikk,
+    { type: 'EnkeltplassOkonomiGodkjent' }
+  >
+}
+
+export const HistorikkEnkeltplassOkonomiGodkjent = ({
+  endringsHistorikk
+}: Props) => {
+  const { endretAv, endretAvEnhet, endret } = endringsHistorikk
+
+  return (
+    <HistorikkElement
+      tittel="Opplæring godkjent"
+      icon={<CheckmarkCircleFillIcon color="var(--ax-text-on-action)" />}
+    >
+      <BodyShort size="small">
+        Pris og betalingsbetingelser er godkjent, og vedtak er fattet.
+      </BodyShort>
+
+      <Detail className="mt-2" textColor="subtle">
+        {`Endret ${formatDate(endret)} av ${endretAv} ${endretAvEnhet}.`}
+      </Detail>
+    </HistorikkElement>
+  )
+}

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
@@ -1,4 +1,4 @@
-import { CheckmarkCircleFillIcon } from '@navikt/aksel-icons'
+import { CaretRightCircleFillIcon } from '@navikt/aksel-icons'
 import { BodyShort, Detail } from '@navikt/ds-react'
 import { DeltakerHistorikk } from '../../model/deltakerHistorikk'
 import { formatDate } from '../../utils/utils'
@@ -19,7 +19,9 @@ export const HistorikkEnkeltplassOkonomiGodkjent = ({
   return (
     <HistorikkElement
       tittel="Opplæring godkjent"
-      icon={<CheckmarkCircleFillIcon color="var(--ax-text-on-action)" />}
+      icon={
+        <CaretRightCircleFillIcon color="var(--ax-text-meta-lime-decoration)" />
+      }
     >
       <BodyShort size="small">
         Pris og betalingsbetingelser er godkjent, og vedtak er fattet.

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
@@ -1,13 +1,14 @@
 import { InformationSquareFillIcon } from '@navikt/aksel-icons'
 import { BodyShort, Detail } from '@navikt/ds-react'
 import type { DeltakerHistorikk } from '../../model/deltakerHistorikk'
+import { HistorikkType } from '../../model/forslag'
 import { formatDate } from '../../utils/utils'
 import { HistorikkElement } from './HistorikkElement'
 
 interface Props {
   endringsHistorikk: Extract<
     DeltakerHistorikk,
-    { type: 'EnkeltplassOkonomiGodkjent' }
+    { type: HistorikkType.EnkeltplassOkonomiGodkjent }
   >
 }
 

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
@@ -1,18 +1,19 @@
 import { InformationSquareFillIcon } from '@navikt/aksel-icons'
 import { BodyShort, Detail } from '@navikt/ds-react'
+import type { DeltakerHistorikk } from '../../model/deltakerHistorikk'
 import { formatDate } from '../../utils/utils'
 import { HistorikkElement } from './HistorikkElement'
 
+interface Props {
+  endringsHistorikk: Extract<
+    DeltakerHistorikk,
+    { type: 'EnkeltplassOkonomiGodkjent' }
+  >
+}
+
 export const HistorikkEnkeltplassOkonomiGodkjent = ({
   endringsHistorikk
-}: {
-  endringsHistorikk: {
-    type: 'EnkeltplassOkonomiGodkjent'
-    endretAv: string
-    endretAvEnhet: string
-    endret: Date
-  }
-}) => {
+}: Props) => {
   const { endretAv, endretAvEnhet, endret } = endringsHistorikk
 
   return (

--- a/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkEnkeltplassOkonomiGodkjent.tsx
@@ -1,27 +1,24 @@
-import { CaretRightCircleFillIcon } from '@navikt/aksel-icons'
+import { InformationSquareFillIcon } from '@navikt/aksel-icons'
 import { BodyShort, Detail } from '@navikt/ds-react'
-import { DeltakerHistorikk } from '../../model/deltakerHistorikk'
 import { formatDate } from '../../utils/utils'
 import { HistorikkElement } from './HistorikkElement'
 
-interface Props {
-  endringsHistorikk: Extract<
-    DeltakerHistorikk,
-    { type: 'EnkeltplassOkonomiGodkjent' }
-  >
-}
-
 export const HistorikkEnkeltplassOkonomiGodkjent = ({
   endringsHistorikk
-}: Props) => {
+}: {
+  endringsHistorikk: {
+    type: 'EnkeltplassOkonomiGodkjent'
+    endretAv: string
+    endretAvEnhet: string
+    endret: Date
+  }
+}) => {
   const { endretAv, endretAvEnhet, endret } = endringsHistorikk
 
   return (
     <HistorikkElement
       tittel="Opplæring godkjent"
-      icon={
-        <CaretRightCircleFillIcon color="var(--ax-text-meta-lime-decoration)" />
-      }
+      icon={<InformationSquareFillIcon color="var(--ax-text-on-action)" />}
     >
       <BodyShort size="small">
         Pris og betalingsbetingelser er godkjent, og vedtak er fattet.

--- a/packages/deltaker-flate-common/components/historikk/HistorikkModal.tsx
+++ b/packages/deltaker-flate-common/components/historikk/HistorikkModal.tsx
@@ -14,6 +14,7 @@ import { HistorikkSoktInn } from './HistorikkSoktInn.tsx'
 import { HistorikkTiltakskoordinatorEndring } from './HistorikkTiltakskoordinatorEndring.tsx'
 import { HistorikkVedtak } from './HistorikkVedtak'
 import { HistorikkVurderingFraArrangor } from './HistorikkVurderingFraArrangor.tsx'
+import { HistorikkEnkeltplassOkonomiGodkjent } from './HistorikkEnkeltplassOkonomiGodkjent.tsx'
 
 interface Props {
   historikk: DeltakerHistorikkListe | null
@@ -73,6 +74,10 @@ const getHistorikkItem = (
         <HistorikkTiltakskoordinatorEndring
           tiltakskoordinatorEndring={historikk}
         />
+      )
+    case HistorikkType.EnkeltplassOkonomiGodkjent:
+      return (
+        <HistorikkEnkeltplassOkonomiGodkjent endringsHistorikk={historikk} />
       )
   }
 }

--- a/packages/deltaker-flate-common/model/deltakerHistorikk.ts
+++ b/packages/deltaker-flate-common/model/deltakerHistorikk.ts
@@ -245,7 +245,7 @@ export const endringFraTiltakskoordinatorSchema = z.object({
   endretAvEnhet: z.string().nullable().optional()
 })
 
-export const enkelplassOkonomiGodkjentSchema = z.object({
+export const enkeltplassOkonomiGodkjentSchema = z.object({
   type: z.literal(HistorikkType.EnkeltplassOkonomiGodkjent),
   endretAv: z.string(),
   endretAvEnhet: z.string(),
@@ -261,7 +261,7 @@ export const deltakerHistorikkSchema = z.discriminatedUnion('type', [
   importertFraArenaSchema,
   vurderingFraArrangorSchema,
   endringFraTiltakskoordinatorSchema,
-  enkelplassOkonomiGodkjentSchema
+  enkeltplassOkonomiGodkjentSchema
 ])
 
 export const deltakerHistorikkListeSchema = z.array(deltakerHistorikkSchema)

--- a/packages/deltaker-flate-common/model/deltakerHistorikk.ts
+++ b/packages/deltaker-flate-common/model/deltakerHistorikk.ts
@@ -245,6 +245,14 @@ export const endringFraTiltakskoordinatorSchema = z.object({
   endretAvEnhet: z.string().nullable().optional()
 })
 
+export const enkelplassOkonomiGodkjentSchema = z.object({
+  type: z.literal(HistorikkType.EnkeltplassOkonomiGodkjent),
+  prisinformasjon: prisinformasjonSchema,
+  endretAv: z.string(),
+  endretAvEnhet: z.string(),
+  endret: dateSchema
+})
+
 export const deltakerHistorikkSchema = z.discriminatedUnion('type', [
   vedtakSchema,
   soktInnSchema,
@@ -253,7 +261,8 @@ export const deltakerHistorikkSchema = z.discriminatedUnion('type', [
   endringFraArrangorSchema,
   importertFraArenaSchema,
   vurderingFraArrangorSchema,
-  endringFraTiltakskoordinatorSchema
+  endringFraTiltakskoordinatorSchema,
+  enkelplassOkonomiGodkjentSchema
 ])
 
 export const deltakerHistorikkListeSchema = z.array(deltakerHistorikkSchema)

--- a/packages/deltaker-flate-common/model/deltakerHistorikk.ts
+++ b/packages/deltaker-flate-common/model/deltakerHistorikk.ts
@@ -247,7 +247,6 @@ export const endringFraTiltakskoordinatorSchema = z.object({
 
 export const enkelplassOkonomiGodkjentSchema = z.object({
   type: z.literal(HistorikkType.EnkeltplassOkonomiGodkjent),
-  prisinformasjon: prisinformasjonSchema,
   endretAv: z.string(),
   endretAvEnhet: z.string(),
   endret: dateSchema

--- a/packages/deltaker-flate-common/model/forslag.ts
+++ b/packages/deltaker-flate-common/model/forslag.ts
@@ -11,7 +11,8 @@ export enum HistorikkType {
   EndringFraArrangor = 'EndringFraArrangor',
   ImportertFraArena = 'ImportertFraArena',
   VurderingFraArrangor = 'VurderingFraArrangor',
-  EndringFraTiltakskoordinator = 'EndringFraTiltakskoordinator'
+  EndringFraTiltakskoordinator = 'EndringFraTiltakskoordinator',
+  EnkeltplassOkonomiGodkjent = 'EnkeltplassOkonomiGodkjent'
 }
 
 export enum ForslagStatusType {


### PR DESCRIPTION
## Description
Legger til støtte for en ny historikk-hendelse for enkeltplass når økonomi er godkjent, slik at hendelsen kan valideres i modellen og vises i historikk-modal.

**Changes:**
- Utvider `HistorikkType` med `EnkeltplassOkonomiGodkjent`.
- Legger til Zod-schema og inkluderer hendelsen i `deltakerHistorikkSchema` (discriminated union).
- Rendrer ny historikk-type i `HistorikkModal` via ny komponent + test.

## Trello card
https://trello.com/c/12gPcams